### PR TITLE
Bug fixes and improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,11 @@ export ZENML_API_TOKEN="your-api-token"
 
 ### Example Usage
 
+> **Hint:** The ZenML Terraform provider is being heavily used in all our Terraform modules. Their code is available on GitHub and can be used as a reference:
+> - [zenml-stack/aws](https://github.com/zenml-io/terraform-aws-zenml-stack)
+> - [zenml-stack/gcp](https://github.com/zenml-io/terraform-gcp-zenml-stack)
+> - [zenml-stack/azure](https://github.com/zenml-io/terraform-azure-zenml-stack)
+
 Here's a basic example of creating a stack with components:
 
 ```hcl

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ terraform {
 
 ### Authentication
 
+#### Service Account API Key
+
 Configure the provider with your ZenML server URL and API key:
 
 ```hcl
@@ -78,6 +80,23 @@ zenml service-account create <MYSERVICEACCOUNTNAME>
 
 This command will print out the ZENML_API_KEY that you can use with this provider.
 
+#### API Token
+
+Alternatively, you can use an API token for authentication:
+
+```hcl
+provider "zenml" {
+  server_url = "https://your-zenml-server.com"
+  api_token  = "your-api-token"
+}
+```
+
+You can also use environment variables:
+```bash
+export ZENML_SERVER_URL="https://your-zenml-server.com"
+export ZENML_API_TOKEN="your-api-token"
+```
+
 ### Example Usage
 
 Here's a basic example of creating a stack with components:
@@ -90,18 +109,9 @@ resource "zenml_service_connector" "gcp" {
   auth_method = "service-account"
   # workspace defaults to "default" if not specified
   
-  resource_types = [
-    "artifact-store",
-    "container-registry",
-    "orchestrator"
-  ]
-  
   configuration = {
     project_id = "my-project"
     location   = "us-central1"
-  }
-  
-  secrets = {
     service_account_json = file("service-account.json")
   }
   

--- a/docs/data-sources/server.md
+++ b/docs/data-sources/server.md
@@ -1,0 +1,50 @@
+---
+page_title: "zenml_server Data Source - terraform-provider-zenml"
+subcategory: ""
+description: |-
+  Data source for retrieving information about the ZenML server.
+---
+
+# zenml_server (Data Source)
+
+Use this data source to retrieve information about the ZenML server.
+
+## Example Usage
+
+```hcl
+data "zenml_server" "server_info" {
+}
+
+output "version" {
+  value = data.zenml_server.server_info.version
+}
+
+output "dashboard_url" {
+  value = data.zenml_server.server_info.dashboard_url
+}
+```
+
+## Argument Reference
+
+The `zenml_server` data source does not take any arguments.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the server.
+* `name` - The name of the server.
+* `version` - The version of the server.
+* `deployment_type` - The deployment type of the server.
+* `auth_scheme` - The authentication scheme of the server.
+* `server_url` - The URL where the server API is hosted.
+* `dashboard_url` - The URL where the server's dashboard is hosted.
+* `metadata` - A map of metadata associated with the server.
+
+## Import
+
+The server info can be imported using the `id`, e.g.
+
+```
+$ terraform import zenml_server.server_info 12345678-1234-1234-1234-123456789012
+```

--- a/docs/data-sources/service_connector.md
+++ b/docs/data-sources/service_connector.md
@@ -38,7 +38,8 @@ In addition to all arguments above, the following attributes are exported:
 * `name` - The name of the service connector.
 * `type` - The type of the service connector (e.g., "gcp", "aws", "azure", etc.).
 * `auth_method` - The authentication method used by the service connector.
-* `resource_types` - A list of resource types supported by this service connector.
+* `resource_type` - The type of resource the service connector is connected to (e.g., "s3-bucket", "docker-registry", etc.).
+* `resource_id` - The ID of the resource the service connector is connected to.
 * `configuration` - A map of configuration key-value pairs for the service connector. Sensitive values are not included.
 * `workspace` - The workspace ID this service connector belongs to.
 * `labels` - A map of labels associated with this service connector.

--- a/docs/data-sources/stack_component.md
+++ b/docs/data-sources/stack_component.md
@@ -39,6 +39,9 @@ In addition to all arguments above, the following attributes are exported:
 * `flavor` - The flavor of the stack component (e.g., "local", "gcp", "aws", etc.).
 * `configuration` - A map of configuration key-value pairs for the stack component.
 * `workspace` - The workspace ID this stack component belongs to.
+* `labels` - A map of labels associated with this stack component.
+* `connector` - The ID of the service connector associated with this stack component.
+* `connector_resource_id` - The ID of the resource the service connector is connected to.
 
 ## Import
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -117,6 +117,7 @@ This command will print out the ZENML_API_KEY that you can use with this provide
 
 * `server_url` - (Optional) The URL of your ZenML server. Can be set with the `ZENML_SERVER_URL` environment variable.
 * `api_key` - (Optional) Your ZenML API key. Can be set with the `ZENML_API_KEY` environment variable.
+* `api_token` - (Optional) Your ZenML API token. Can be set with the `ZENML_API_TOKEN` environment variable.
 
 ## Resources
 
@@ -126,6 +127,7 @@ This command will print out the ZENML_API_KEY that you can use with this provide
 
 ## Data Sources
 
+* [zenml_server](data-sources/server.md) - Retrieve information about the ZenML server
 * [zenml_service_connector](data-sources/service_connector.md) - Retrieve information about a service connector
 * [zenml_stack_component](data-sources/stack_component.md) - Retrieve information about a stack component
 * [zenml_stack](data-sources/stack.md) - Retrieve information about a stack

--- a/docs/index.md
+++ b/docs/index.md
@@ -113,6 +113,18 @@ zenml service-account create <MYSERVICEACCOUNTNAME>
 
 This command will print out the ZENML_API_KEY that you can use with this provider.
 
+#### API Token
+
+Alternatively, you can use an API token for authentication, but this is not recommended for production use because API
+tokens can expire:
+
+```hcl
+provider "zenml" {
+  server_url = "https://your-zenml-server.com"
+  api_token  = "your-api-token"
+}
+```
+
 ## Provider Arguments
 
 * `server_url` - (Optional) The URL of your ZenML server. Can be set with the `ZENML_SERVER_URL` environment variable.

--- a/examples/complete-azure/main.tf
+++ b/examples/complete-azure/main.tf
@@ -1,0 +1,245 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.0"
+    }
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = "~> 2.0"
+    }
+    zenml = {
+        source = "zenml-io/zenml"
+    }
+  }
+}
+
+provider "zenml" {
+  server_url = var.zenml_server_url
+  api_key    = var.zenml_api_key
+}
+
+provider "azurerm" {
+    features {
+        resource_group {
+            prevent_deletion_if_contains_resources = false
+        }
+    }
+}
+
+data "azurerm_client_config" "current" {}
+data "azuread_client_config" "current" {}
+# Get current subscription details
+data "azurerm_subscription" "primary" {
+  # This will get the subscription ID from the provider configuration
+}
+
+# Create resource group to hold all resources
+
+resource "azurerm_resource_group" "resource_group" {
+  name     = "zenml-${var.environment}"
+  location = var.location
+}
+
+# Create storage account and blob storage container to store ZenML artifacts
+
+resource "azurerm_storage_account" "artifacts" {
+  name                     = "zenml${var.environment}"
+  resource_group_name      = azurerm_resource_group.resource_group.name
+  location                 = azurerm_resource_group.resource_group.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_storage_container" "artifact_container" {
+  name                  = "zenml${var.environment}"
+  storage_account_name  = azurerm_storage_account.artifacts.name
+  container_access_type = "private"
+}
+
+# Create Azure Container Registry to store ZenML containers
+
+resource "azurerm_container_registry" "containers" {
+  name                = "zenml${var.environment}"
+  resource_group_name = azurerm_resource_group.resource_group.name
+  location            = azurerm_resource_group.resource_group.location
+  sku                 = "Basic"
+  admin_enabled       = true
+}
+
+# Create AzureML workspace and all related resources to run ZenML pipelines
+
+resource "azurerm_application_insights" "application_insights" {
+  name                = "zenml-${var.environment}"
+  resource_group_name = azurerm_resource_group.resource_group.name
+  location            = azurerm_resource_group.resource_group.location
+  application_type    = "web"
+}
+
+resource "azurerm_key_vault" "key_vault" {
+  name                = "zenml-${var.environment}"
+  resource_group_name = azurerm_resource_group.resource_group.name
+  location            = azurerm_resource_group.resource_group.location
+  tenant_id           = data.azurerm_client_config.current.tenant_id
+  sku_name            = "standard"
+}
+
+resource "azurerm_machine_learning_workspace" "azureml_workspace" {
+  name                    = "zenml-${var.environment}"
+  resource_group_name     = azurerm_resource_group.resource_group.name
+  location                = azurerm_resource_group.resource_group.location
+  storage_account_id      = azurerm_storage_account.artifacts.id
+  container_registry_id   = azurerm_container_registry.containers.id
+  application_insights_id = azurerm_application_insights.application_insights.id
+  key_vault_id            = azurerm_key_vault.key_vault.id
+  public_network_access_enabled = true
+  identity {
+    type = "SystemAssigned"
+  }
+  sku_name = "Basic"
+}
+
+# Create Service Principal with required permissions and password
+
+resource "azuread_application" "service_principal_app" {
+  display_name = "zenml-${var.environment}"
+  owners       = [data.azuread_client_config.current.object_id]
+}
+
+resource "azuread_service_principal" "service_principal" {
+  client_id = azuread_application.service_principal_app.client_id
+  owners       = [data.azuread_client_config.current.object_id]
+}
+
+resource "azuread_service_principal_password" "service_principal_password" {
+  service_principal_id = azuread_service_principal.service_principal.object_id
+}
+
+# Assign roles to the Service Principal
+
+resource "azurerm_role_assignment" "storage_blob_data_contributor_role" {
+  scope                = azurerm_storage_account.artifacts.id
+  role_definition_name = "Storage Blob Data Contributor"
+  principal_id         = azuread_service_principal.service_principal.object_id
+}
+
+resource "azurerm_role_assignment" "acr_push_role" {
+  scope                = azurerm_container_registry.containers.id
+  role_definition_name = "AcrPush"
+  principal_id         = azuread_service_principal.service_principal.object_id
+}
+
+resource "azurerm_role_assignment" "acr_pull_role" {
+  scope                = azurerm_container_registry.containers.id
+  role_definition_name = "AcrPull"
+  principal_id         = azuread_service_principal.service_principal.object_id
+}
+
+resource "azurerm_role_assignment" "acr_contributor_role" {
+  scope                = azurerm_container_registry.containers.id
+  role_definition_name = "Contributor"
+  principal_id         = azuread_service_principal.service_principal.object_id
+}
+
+resource "azurerm_role_assignment" "azureml_compute_operator" {
+  scope                = azurerm_machine_learning_workspace.azureml_workspace.id
+  role_definition_name = "AzureML Compute Operator"
+  principal_id         = azuread_service_principal.service_principal.object_id
+}
+
+resource "azurerm_role_assignment" "azureml_data_scientist" {
+  scope                = azurerm_machine_learning_workspace.azureml_workspace.id
+  role_definition_name = "AzureML Data Scientist"
+  principal_id         = azuread_service_principal.service_principal.object_id
+}
+
+# ZenML service Connector for Azure
+
+resource "zenml_service_connector" "azure" {
+  name           = "zenml-${var.environment}"
+  type           = "azure"
+  auth_method    = "service-principal"
+
+  configuration = {
+    subscription_id = "${data.azurerm_client_config.current.subscription_id}"
+    resource_group = "${azurerm_resource_group.resource_group.name}"
+    storage_account = "${azurerm_storage_account.artifacts.name}"
+    tenant_id = "${data.azurerm_client_config.current.tenant_id}"
+    client_id = "${azuread_application.service_principal_app.client_id}"
+    client_secret = "${azuread_service_principal_password.service_principal_password.value}"
+  }
+
+  labels = {
+    environment = var.environment
+    managed_by  = "terraform"
+  }
+}
+
+# Artifact Store Component
+resource "zenml_stack_component" "artifact_store" {
+  name      = "abc-${var.environment}"
+  type      = "artifact_store"
+  flavor    = "azure"
+
+  configuration = {
+    path = "az://${azurerm_storage_container.artifact_container.name}"
+  }
+
+  connector_id = zenml_service_connector.azure.id
+
+  labels = {
+    environment = var.environment
+  }
+}
+
+# Container Registry Component
+resource "zenml_stack_component" "container_registry" {
+  name      = "acr-${var.environment}"
+  type      = "container_registry"
+  flavor    = "azure"
+
+  configuration = {
+    uri = azurerm_container_registry.containers.login_server
+  }
+
+  connector_id = zenml_service_connector.azure.id
+
+  labels = {
+    environment = var.environment
+  }
+}
+
+# SageMaker Orchestrator
+resource "zenml_stack_component" "orchestrator" {
+  name      = "azureml-${var.environment}"
+  type      = "orchestrator"
+  flavor    = "azureml"
+
+  configuration = {
+    subscription_id = "${data.azurerm_client_config.current.subscription_id}"
+    resource_group = "${azurerm_resource_group.resource_group.name}"
+    workspace = "zenml-${var.environment}"
+  }
+
+  connector_id = zenml_service_connector.azure.id
+
+  labels = {
+    environment = var.environment
+  }
+}
+
+# Complete Stack
+resource "zenml_stack" "azure_stack" {
+  name = "azure-${var.environment}"
+
+  components = {
+    artifact_store     = zenml_stack_component.artifact_store.id
+    container_registry = zenml_stack_component.container_registry.id
+    orchestrator      = zenml_stack_component.orchestrator.id
+  }
+
+  labels = {
+    environment = var.environment
+    managed_by  = "terraform"
+  }
+}

--- a/examples/complete-azure/outputs.tf
+++ b/examples/complete-azure/outputs.tf
@@ -1,16 +1,16 @@
 output "stack_id" {
   description = "ID of the created ZenML stack"
-  value       = zenml_stack.aws_stack.id
+  value       = zenml_stack.azure_stack.id
 }
 
 output "stack_name" {
   description = "Name of the created ZenML stack"
-  value       = zenml_stack.aws_stack.name
+  value       = zenml_stack.azure_stack.name
 }
 
 output "artifact_store_path" {
-  description = "S3 path for the artifact store"
-  value       = "s3://${aws_s3_bucket.artifacts.bucket}/artifacts"
+  description = "Azure Blobg storage path for the artifact store"
+  value       = "az://${azurerm_storage_container.artifact_container.name}"
 }
 
 output "artifact_store_id" {
@@ -19,8 +19,8 @@ output "artifact_store_id" {
 }
 
 output "container_registry_uri" {
-  description = "URI of the ECR repository"
-  value       = aws_ecr_repository.containers.repository_url
+  description = "URI of the Azure Container Registry repository"
+  value       = azurerm_container_registry.containers.login_server
 }
 
 output "container_registry_id" {
@@ -33,12 +33,12 @@ output "orchestrator_id" {
   value       = zenml_stack_component.orchestrator.id
 }
 
-output "role_arn" {
-  description = "ARN of the IAM role created for ZenML"
-  value       = aws_iam_role.zenml.arn
+output "principal_id" {
+  description = "Application client ID of the service principal"
+  value       = azuread_application.service_principal_app.client_id
 }
 
 output "service_connector_id" {
-  description = "ID of the AWS service connector"
-  value       = zenml_service_connector.aws.id
+  description = "ID of the Azure service connector"
+  value       = zenml_service_connector.azure.id
 }

--- a/examples/complete-azure/variables.tf
+++ b/examples/complete-azure/variables.tf
@@ -9,10 +9,11 @@ variable "zenml_api_key" {
   description = "API key for authenticating with the ZenML server"
 }
 
-variable "region" {
+variable "location" {
+  description = "The Azure region where resources will be created"
+  # Make a choice from the list of Azure regions
   type        = string
-  default     = "eu-central-1"
-  description = "AWS region to deploy resources in"
+  default     = "westus"
 }
 
 variable "environment" {

--- a/examples/complete-gcp/outputs.tf
+++ b/examples/complete-gcp/outputs.tf
@@ -1,8 +1,12 @@
 
-# examples/complete-gcp/outputs.tf
 output "stack_id" {
   value       = zenml_stack.gcp_stack.id
   description = "The ID of the created ZenML stack"
+}
+
+output "stack_name" {
+  description = "Name of the created ZenML stack"
+  value       = zenml_stack.gcp_stack.name
 }
 
 output "artifact_store_path" {
@@ -10,7 +14,27 @@ output "artifact_store_path" {
   description = "GCS path for artifacts"
 }
 
+output "artifact_store_id" {
+  description = "ID of the artifact store component"
+  value       = zenml_stack_component.artifact_store.id
+}
+
 output "container_registry_uri" {
   value       = "${var.region}-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.containers.repository_id}"
   description = "GCR URI for container images"
+}
+
+output "container_registry_id" {
+  description = "ID of the container registry component"
+  value       = zenml_stack_component.container_registry.id
+}
+
+output "orchestrator_id" {
+  description = "ID of the orchestrator component"
+  value       = zenml_stack_component.orchestrator.id
+}
+
+output "service_connector_id" {
+  description = "ID of the AWS service connector"
+  value       = zenml_service_connector.gcp.id
 }

--- a/examples/complete-gcp/variables.tf
+++ b/examples/complete-gcp/variables.tf
@@ -2,14 +2,12 @@
 variable "zenml_server_url" {
   type        = string
   description = "URL of the ZenML server"
-  default     = "http://127.0.0.1:8237"
 }
 
 variable "zenml_api_key" {
   type        = string
   description = "API key for ZenML server"
   sensitive   = true
-  default     = "ZENKEY_eyJpZCI6ImNiZDYxZDE1LWM3ZGEtNDdjMS1hNjg2LWRjYWZjYWMxYmNiMSIsImtleSI6IjExZTI4ZGY5M2RiNWJjMmVjNDI4ZmVjZTBjNTNlYTRkNjY5NGViOGU4ZGJhNTVkNmI2ZTFkMTc4NDU4MzY2OGUifQ=="
 }
 
 variable "project_id" {
@@ -26,11 +24,5 @@ variable "region" {
 variable "environment" {
   type        = string
   description = "Environment name (e.g. dev, staging, prod)"
-  default     = "dev"
-}
-
-variable "gcp_service_account_key" {
-  type        = string
-  description = "GCP service account key JSON"
-  sensitive   = true
+  default     = "stefan"
 }

--- a/examples/complete-gcp/variables.tf
+++ b/examples/complete-gcp/variables.tf
@@ -1,4 +1,3 @@
-# examples/complete-gcp/variables.tf
 variable "zenml_server_url" {
   type        = string
   description = "URL of the ZenML server"
@@ -18,7 +17,7 @@ variable "project_id" {
 variable "region" {
   type        = string
   description = "GCP region"
-  default     = "us-central1"
+  default     = "europe-west3"
 }
 
 variable "environment" {

--- a/examples/complete-gcp/variables.tf
+++ b/examples/complete-gcp/variables.tf
@@ -24,5 +24,5 @@ variable "region" {
 variable "environment" {
   type        = string
   description = "Environment name (e.g. dev, staging, prod)"
-  default     = "stefan"
+  default     = "dev"
 }

--- a/internal/provider/client.go
+++ b/internal/provider/client.go
@@ -46,10 +46,28 @@ func (c *Client) getAPIToken() (string, error) {
 			// Token is still valid
 			return c.APIToken, nil
 		}
-	}
+		if c.APIKey == "" {
+			// Token has expired and we can't refresh it
+			return "", fmt.Errorf(`The API token configured for the ZenML Terraform provider has expired.
 
-	if c.APIKey == "" {
-		return "", fmt.Errorf("API key is required to get an API token")
+Please reconfigure the provider with a new API token or an API key.
+It is recommended to use an API key for long-term Terraform management operations, as API tokens expire after a short period of time.
+
+More information on how to configure a service account and an API key can be found at https://docs.zenml.io/how-to/connecting-to-zenml/connect-with-a-service-account.
+
+To configure the ZenML Terraform provider, add the following block to your Terraform configuration:
+
+provider "zenml" {
+	server_url = "https://example.zenml.io"
+	api_key   = "your api key"
+}
+
+or use the ZENML_API_KEY environment variable to set the API key.
+`)
+		}
+	} else if c.APIKey == "" {
+		// Shouldn't happen, as the provider should have already validated this.
+		return "", fmt.Errorf("an API key or an API token must be configured for the ZenML Terraform provider to be able to authenticate with your ZenML server")
 	}
 
 	// Get a new token from the API key using the password flow

--- a/internal/provider/data_source_server.go
+++ b/internal/provider/data_source_server.go
@@ -1,0 +1,97 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceServer() *schema.Resource {
+	return &schema.Resource{
+		Description: "Data source for global ZenML server information",
+		ReadContext: dataSourceServerRead,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Description: "Server name",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"version": {
+				Description: "Server version",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"deployment_type": {
+				Description: "Server deployment type",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"auth_scheme": {
+				Description: "Server authentication scheme",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"server_url": {
+				Description: "Server API URL",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"dashboard_url": {
+				Description: "Server dashboard URL",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"metadata": {
+				Description: "Server metadata",
+				Type:        schema.TypeMap,
+				Computed:    true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+		},
+	}
+}
+
+func dataSourceServerRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	c := m.(*Client)
+
+	server, err := c.GetServerInfo()
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error fetching server info: %v", err))
+	}
+
+	d.SetId(server.ID)
+
+	if err := d.Set("name", server.Name); err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err := d.Set("version", server.Version); err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err := d.Set("deployment_type", server.DeploymentType); err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err := d.Set("auth_scheme", server.AuthScheme); err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err := d.Set("server_url", server.ServerURL); err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err := d.Set("dashboard_url", server.DashboardURL); err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err := d.Set("metadata", server.Metadata); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}

--- a/internal/provider/data_source_server.go
+++ b/internal/provider/data_source_server.go
@@ -58,7 +58,7 @@ func dataSourceServer() *schema.Resource {
 func dataSourceServerRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	c := m.(*Client)
 
-	server, err := c.GetServerInfo()
+	server, err := c.GetServerInfo(ctx)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error fetching server info: %v", err))
 	}

--- a/internal/provider/data_source_service_connector.go
+++ b/internal/provider/data_source_service_connector.go
@@ -97,14 +97,19 @@ func dataSourceServiceConnectorRead(ctx context.Context, d *schema.ResourceData,
 	var connector *ServiceConnectorResponse = nil
 
 	if id != "" {
-		connector, err = c.GetServiceConnector(id)
+		connector, err = c.GetServiceConnector(ctx, id)
 	} else if name != "" {
-		connector, err = c.GetServiceConnectorByName(workspace, name)
+		connector, err = c.GetServiceConnectorByName(ctx, workspace, name)
 	} else {
 		return diag.FromErr(fmt.Errorf("either 'id' or 'name' must be set"))
 	}
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error getting service connector: %v", err))
+	}
+	if connector == nil {
+		// Connector not found
+		d.SetId("")
+		return nil
 	}
 
 	d.SetId(connector.ID)

--- a/internal/provider/data_source_service_connector.go
+++ b/internal/provider/data_source_service_connector.go
@@ -2,7 +2,9 @@ package provider
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -12,6 +14,11 @@ func dataSourceServiceConnector() *schema.Resource {
 		Description: "Data source for ZenML service connectors",
 		ReadContext: dataSourceServiceConnectorRead,
 		Schema: map[string]*schema.Schema{
+			"id": {
+				Description: "ID of the service connector",
+				Type:        schema.TypeString,
+				Optional:    true,
+			},
 			"workspace": {
 				Description: "Name of the workspace (defaults to 'default')",
 				Type:        schema.TypeString,
@@ -21,10 +28,15 @@ func dataSourceServiceConnector() *schema.Resource {
 			"name": {
 				Description: "Name of the service connector",
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
 			},
-			"connector_type": {
+			"type": {
 				Description: "Type of the service connector",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"auth_method": {
+				Description: "Authentication method of the service connector",
 				Type:        schema.TypeString,
 				Computed:    true,
 			},
@@ -35,6 +47,7 @@ func dataSourceServiceConnector() *schema.Resource {
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
+				Sensitive: true,
 			},
 			"labels": {
 				Description: "Labels associated with the service connector",
@@ -44,6 +57,11 @@ func dataSourceServiceConnector() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
+			"resource_type": {
+				Description: "Resource type associated with the service connector",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
 			"resource_id": {
 				Description: "Resource ID associated with the service connector",
 				Type:        schema.TypeString,
@@ -51,6 +69,16 @@ func dataSourceServiceConnector() *schema.Resource {
 			},
 			"expires_at": {
 				Description: "Expiration timestamp of the service connector",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"created": {
+				Description: "Timestamp when the service connector was created",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"updated": {
+				Description: "Timestamp when the service connector was last updated",
 				Type:        schema.TypeString,
 				Computed:    true,
 			},
@@ -63,34 +91,97 @@ func dataSourceServiceConnectorRead(ctx context.Context, d *schema.ResourceData,
 
 	workspace := d.Get("workspace").(string)
 	name := d.Get("name").(string)
+	id := d.Get("id").(string)
 
-	connector, err := c.GetServiceConnectorByName(workspace, name)
+	var err error = nil
+	var connector *ServiceConnectorResponse = nil
+
+	if id != "" {
+		connector, err = c.GetServiceConnector(id)
+	} else if name != "" {
+		connector, err = c.GetServiceConnectorByName(workspace, name)
+	} else {
+		return diag.FromErr(fmt.Errorf("either 'id' or 'name' must be set"))
+	}
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error getting service connector: %v", err))
 	}
 
 	d.SetId(connector.ID)
-	
-	if err := d.Set("connector_type", connector.Body.ConnectorType); err != nil {
+
+	if err := d.Set("name", connector.Name); err != nil {
 		return diag.FromErr(err)
 	}
 
-	if err := d.Set("configuration", connector.Metadata.Configuration); err != nil {
-		return diag.FromErr(err)
-	}
+	if connector.Body != nil {
 
-	if err := d.Set("labels", connector.Metadata.Labels); err != nil {
-		return diag.FromErr(err)
-	}
+		connector_type := ""
 
-	if connector.Body.ResourceID != nil {
-		if err := d.Set("resource_id", *connector.Body.ResourceID); err != nil {
+		// Unmarshal the connector type, which can be either a string or a struct
+		// Try to unmarshal as string
+		err = json.Unmarshal(connector.Body.ConnectorType, &connector_type)
+		if err != nil {
+			var type_struct ServiceConnectorType
+			// Try to unmarshal as struct
+			if err = json.Unmarshal(connector.Body.ConnectorType, &type_struct); err == nil {
+				connector_type = type_struct.ConnectorType
+			}
+		}
+
+		if err := d.Set("type", connector_type); err != nil {
+			return diag.FromErr(err)
+		}
+
+		if err := d.Set("auth_method", connector.Body.AuthMethod); err != nil {
+			return diag.FromErr(err)
+		}
+
+		// If there are multiple resource types, leave the resource_type field empty
+		if len(connector.Body.ResourceTypes) == 1 {
+			d.Set("resource_type", connector.Body.ResourceTypes[0])
+		} else {
+			d.Set("resource_type", "")
+		}
+
+		if connector.Body.ResourceID != nil {
+			if err := d.Set("resource_id", *connector.Body.ResourceID); err != nil {
+				return diag.FromErr(err)
+			}
+		} else {
+			if err := d.Set("resource_id", ""); err != nil {
+				return diag.FromErr(err)
+			}
+		}
+
+		if connector.Body.ExpiresAt != nil {
+			if err := d.Set("expires_at", *connector.Body.ExpiresAt); err != nil {
+				return diag.FromErr(err)
+			}
+		} else {
+			if err := d.Set("expires_at", ""); err != nil {
+				return diag.FromErr(err)
+			}
+		}
+
+		if err := d.Set("created", connector.Body.Created); err != nil {
+			return diag.FromErr(err)
+		}
+
+		if err := d.Set("updated", connector.Body.Updated); err != nil {
 			return diag.FromErr(err)
 		}
 	}
 
-	if connector.Body.ExpiresAt != nil {
-		if err := d.Set("expires_at", *connector.Body.ExpiresAt); err != nil {
+	if connector.Metadata != nil {
+		if err := d.Set("workspace", connector.Metadata.Workspace.Name); err != nil {
+			return diag.FromErr(err)
+		}
+
+		if err := d.Set("configuration", connector.Metadata.Configuration); err != nil {
+			return diag.FromErr(err)
+		}
+
+		if err := d.Set("labels", connector.Metadata.Labels); err != nil {
 			return diag.FromErr(err)
 		}
 	}

--- a/internal/provider/data_source_stack.go
+++ b/internal/provider/data_source_stack.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"sort"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -129,7 +130,22 @@ func dataSourceStackRead(ctx context.Context, d *schema.ResourceData, m interfac
 
 		// Handle components
 		var components []map[string]string
-		for _, componentList := range stack.Metadata.Components {
+
+		// We need to keep a sorted list of components, otherwise the order
+		// of components will change on each read
+
+		// Extract keys
+		keys := make([]string, 0, len(stack.Metadata.Components))
+		for key, _ := range stack.Metadata.Components {
+			keys = append(keys, key)
+		}
+
+		// Sort keys
+		sort.Strings(keys)
+
+		// Iterate over sorted keys
+		for _, key := range keys {
+			componentList := stack.Metadata.Components[key]
 			var componentData map[string]string
 			for _, component := range componentList {
 				componentData = map[string]string{

--- a/internal/provider/data_source_stack.go
+++ b/internal/provider/data_source_stack.go
@@ -89,7 +89,7 @@ func dataSourceStackRead(ctx context.Context, d *schema.ResourceData, m interfac
 
 	if id != "" {
 		// Get stack by ID
-		stack, err = c.GetStack(id)
+		stack, err = c.GetStack(ctx, id)
 		if err != nil {
 			return diag.FromErr(fmt.Errorf("error getting stack: %v", err))
 		}
@@ -102,7 +102,7 @@ func dataSourceStackRead(ctx context.Context, d *schema.ResourceData, m interfac
 			},
 		}
 
-		stacks, err := c.ListStacks(params)
+		stacks, err := c.ListStacks(ctx, params)
 		if err != nil {
 			return diag.FromErr(fmt.Errorf("error listing stacks: %v", err))
 		}
@@ -114,6 +114,12 @@ func dataSourceStackRead(ctx context.Context, d *schema.ResourceData, m interfac
 		stack = &stacks.Items[0]
 	} else {
 		return diag.FromErr(fmt.Errorf("either 'id' or 'name' must be set"))
+	}
+
+	if stack == nil {
+		// Stack not found
+		d.SetId("")
+		return nil
 	}
 
 	d.SetId(stack.ID)

--- a/internal/provider/data_source_stack_component.go
+++ b/internal/provider/data_source_stack_component.go
@@ -134,7 +134,7 @@ func dataSourceStackComponentRead(ctx context.Context, d *schema.ResourceData, m
 	var err error = nil
 
 	if id != "" {
-		component, err = c.GetComponent(id)
+		component, err = c.GetComponent(ctx, id)
 		if err != nil {
 			return diag.FromErr(fmt.Errorf("error getting stack component: %v", err))
 		}
@@ -148,7 +148,7 @@ func dataSourceStackComponentRead(ctx context.Context, d *schema.ResourceData, m
 			},
 		}
 
-		components, err := c.ListStackComponents(workspace, params)
+		components, err := c.ListStackComponents(ctx, workspace, params)
 		if err != nil {
 			return diag.FromErr(fmt.Errorf("error listing stack components: %v", err))
 		}
@@ -162,6 +162,12 @@ func dataSourceStackComponentRead(ctx context.Context, d *schema.ResourceData, m
 
 	} else {
 		return diag.FromErr(fmt.Errorf("either 'id' or 'name' and 'type' must be set"))
+	}
+
+	if component == nil {
+		// Component not found
+		d.SetId("")
+		return nil
 	}
 
 	d.SetId(component.ID)

--- a/internal/provider/data_source_stack_component.go
+++ b/internal/provider/data_source_stack_component.go
@@ -196,16 +196,27 @@ func dataSourceStackComponentRead(ctx context.Context, d *schema.ResourceData, m
 		if component.Metadata.Connector != nil {
 
 			connector_type := ""
+			resource_id := ""
+			resource_types := []string{}
 
-			// Unmarshal the connector type, which can be either a string or a struct
-			// Try to unmarshal as string
-			err := json.Unmarshal(component.Metadata.Connector.Body.ConnectorType, &connector_type)
-			if err != nil {
-				var type_struct ServiceConnectorType
-				// Try to unmarshal as struct
-				if err := json.Unmarshal(component.Metadata.Connector.Body.ConnectorType, &type_struct); err == nil {
-					connector_type = type_struct.ConnectorType
+			if component.Metadata.Connector.Body != nil {
+
+				// Unmarshal the connector type, which can be either a string or a struct
+				// Try to unmarshal as string
+				err := json.Unmarshal(component.Metadata.Connector.Body.ConnectorType, &connector_type)
+				if err != nil {
+					var type_struct ServiceConnectorType
+					// Try to unmarshal as struct
+					if err := json.Unmarshal(component.Metadata.Connector.Body.ConnectorType, &type_struct); err == nil {
+						connector_type = type_struct.ConnectorType
+					}
 				}
+
+				if component.Metadata.Connector.Body.ResourceID != nil {
+					resource_id = *component.Metadata.Connector.Body.ResourceID
+				}
+
+				resource_types = component.Metadata.Connector.Body.ResourceTypes
 			}
 
 			connector := []interface{}{
@@ -213,8 +224,8 @@ func dataSourceStackComponentRead(ctx context.Context, d *schema.ResourceData, m
 					"id":             component.Metadata.Connector.ID,
 					"name":           component.Metadata.Connector.Name,
 					"connector_type": connector_type,
-					"resource_id":    component.Metadata.Connector.Body.ResourceID,
-					"resource_types": component.Metadata.Connector.Body.ResourceTypes,
+					"resource_id":    resource_id,
+					"resource_types": resource_types,
 				},
 			}
 			if err := d.Set("connector", connector); err != nil {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -3,8 +3,9 @@ package provider
 
 import (
 	"context"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func Provider() *schema.Provider {
@@ -20,14 +21,12 @@ func Provider() *schema.Provider {
 				Optional:    true,
 				Sensitive:   true,
 				DefaultFunc: schema.EnvDefaultFunc("ZENML_API_KEY", nil),
-				ExactlyOneOf: []string{"api_key", "api_token"},
 			},
 			"api_token": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Sensitive:   true,
 				DefaultFunc: schema.EnvDefaultFunc("ZENML_API_TOKEN", nil),
-				ExactlyOneOf: []string{"api_key", "api_token"},
 			},
 		},
 		ResourcesMap: map[string]*schema.Resource{
@@ -52,11 +51,27 @@ func providerConfigure(_ context.Context, d *schema.ResourceData) (interface{}, 
 	apiKey := d.Get("api_key").(string)
 	apiToken := d.Get("api_token").(string)
 
+	// Should be handled by the schema
 	if serverURL == "" {
-		return nil, diag.Errorf("server_url cannot be empty")
+		return nil, diag.Errorf("server_url must be configured")
 	}
 	if apiKey == "" && apiToken == "" {
-		return nil, diag.Errorf("api_key and api_token cannot both be empty")
+		return nil, diag.Errorf(`an API key or an API token must be configured for the ZenML Terraform provider to be able to authenticate with your ZenML server.
+
+		It is recommended to use an API key for long-term Terraform management operations, as API tokens expire after a short period of time.
+		
+		More information on how to configure a service account and an API key can be found at https://docs.zenml.io/how-to/connecting-to-zenml/connect-with-a-service-account.
+		
+		To configure the ZenML Terraform provider with an API key, add the following block to your Terraform configuration:
+		
+		provider "zenml" {
+			server_url = "https://example.zenml.io"
+			api_key   = "your api key"
+		}
+		
+		or use the ZENML_API_KEY environment variable to set the API key.
+		`)
+
 	}
 
 	client := NewClient(serverURL, apiKey, apiToken)

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -27,7 +27,14 @@ func testAccPreCheck(t *testing.T) {
 	if v := os.Getenv("ZENML_SERVER_URL"); v == "" {
 		t.Fatal("ZENML_SERVER_URL must be set for acceptance tests")
 	}
-	if v := os.Getenv("ZENML_API_KEY"); v == "" {
-		t.Fatal("ZENML_API_KEY must be set for acceptance tests")
+	creds := []string{"ZENML_API_KEY", "ZENML_API_TOKEN"}
+	v:=""
+	for _, cred := range creds {
+		v = os.Getenv(cred)
+	}
+	if v == "" {
+		t.Fatal(
+			"ZENML_API_KEY or ZENML_API_TOKEN must be set for acceptance tests",
+		)
 	}
 }

--- a/internal/provider/resource_service_connector.go
+++ b/internal/provider/resource_service_connector.go
@@ -216,7 +216,9 @@ func resourceServiceConnectorRead(d *schema.ResourceData, m interface{}) error {
 	}
 
 	if connector.Metadata != nil {
-		d.Set("workspace", connector.Metadata.Workspace.Name)
+		if connector.Metadata.Workspace.Name != "default" {
+			d.Set("workspace", connector.Metadata.Workspace.Name)
+		}
 		d.Set("configuration", connector.Metadata.Configuration)
 		d.Set("labels", connector.Metadata.Labels)
 	}

--- a/internal/provider/resource_service_connector_test.go
+++ b/internal/provider/resource_service_connector_test.go
@@ -2,6 +2,7 @@
 package provider
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"testing"
@@ -85,7 +86,7 @@ func testAccCheckServiceConnectorExists(n string) resource.TestCheckFunc {
 		}
 
 		client := testAccProvider.Meta().(*Client)
-		_, err := client.GetServiceConnector(rs.Primary.ID)
+		_, err := client.GetServiceConnector(context.Background(), rs.Primary.ID)
 		if err != nil {
 			return fmt.Errorf("Service Connector not found: %v", err)
 		}
@@ -102,7 +103,7 @@ func testAccCheckServiceConnectorDestroy(s *terraform.State) error {
 			continue
 		}
 
-		_, err := client.GetServiceConnector(rs.Primary.ID)
+		_, err := client.GetServiceConnector(context.Background(), rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("Service Connector still exists")
 		}

--- a/internal/provider/resource_service_connector_test.go
+++ b/internal/provider/resource_service_connector_test.go
@@ -28,14 +28,11 @@ func TestAccServiceConnector_basic(t *testing.T) {
 						"zenml_service_connector.test", "auth_method", "service-account"),
 					resource.TestCheckResourceAttr(
 						"zenml_service_connector.test", "configuration.project_id", "test-project"),
+					resource.TestCheckResourceAttrSet(
+						"zenml_service_connector.test", "configuration.service_account_json"),
 					// Add resource_types validation
 					resource.TestCheckResourceAttr(
-						"zenml_service_connector.test", "resource_types.#", "1"),
-					resource.TestCheckResourceAttr(
-						"zenml_service_connector.test", "resource_types.0", "artifact-store"),
-					// Add at least one secrets check
-					resource.TestCheckResourceAttrSet(
-						"zenml_service_connector.test", "secrets.service_account_json"),
+						"zenml_service_connector.test", "resource_type", "gcs-bucket"),
 				),
 			},
 			{
@@ -43,8 +40,6 @@ func TestAccServiceConnector_basic(t *testing.T) {
 				ResourceName:      "zenml_service_connector.test",
 				ImportState:       true,
 				ImportStateVerify: true,
-				// Don't verify sensitive fields
-				ImportStateVerifyIgnore: []string{"secrets"},
 			},
 		},
 	})
@@ -125,13 +120,10 @@ resource "zenml_service_connector" "test" {
 	workspace   = "%s"
 	user        = "%s"
 	
-	resource_types = ["artifact-store"]
+	resource_types = ["gcs-bucket"]
 	
 	configuration = {
 		project_id = "test-project"
-	}
-	
-	secrets = {
 		service_account_json = jsonencode({
 			"type": "service_account",
 			"project_id": "test-project"
@@ -153,19 +145,10 @@ resource "zenml_service_connector" "test" {
 	auth_method = "service-account"
 	user        = "user-uuid"
 	workspace   = "workspace-uuid"
-	
-	resource_types = [
-		"artifact-store",
-		"container-registry",
-		"orchestrator"
-	]
-	
+		
 	configuration = {
 		project_id = "test-project"
 		region     = "us-central1"
-	}
-	
-	secrets = {
 		service_account_json = jsonencode({
 			"type": "service_account",
 			"project_id": "test-project"
@@ -178,3 +161,4 @@ resource "zenml_service_connector" "test" {
 	}
 }
 `
+}

--- a/internal/provider/resource_stack.go
+++ b/internal/provider/resource_stack.go
@@ -2,10 +2,11 @@
 package provider
 
 import (
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"context"
 	"fmt"
 	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func resourceStack() *schema.Resource {
@@ -87,12 +88,12 @@ func resourceStackCreate(d *schema.ResourceData, m interface{}) error {
 
 	// Handle components
 	if v, ok := d.GetOk("components"); ok {
-			components := make(map[string][]string)
-			for k, v := range v.(map[string]interface{}) {
-				// Convert single ID to array of IDs since API expects array
-				components[k] = []string{v.(string)}
-			}
-			stack.Components = components
+		components := make(map[string][]string)
+		for k, v := range v.(map[string]interface{}) {
+			// Convert single ID to array of IDs since API expects array
+			components[k] = []string{v.(string)}
+		}
+		stack.Components = components
 	}
 
 	// Handle labels
@@ -139,6 +140,11 @@ func resourceStackRead(d *schema.ResourceData, m interface{}) error {
 
 	// Handle labels if present
 	if stack.Metadata != nil && stack.Metadata.Labels != nil {
+
+		if stack.Metadata.Workspace.Name != "default" {
+			d.Set("workspace", stack.Metadata.Workspace.Name)
+		}
+
 		d.Set("labels", stack.Metadata.Labels)
 	}
 

--- a/internal/provider/resource_stack_component.go
+++ b/internal/provider/resource_stack_component.go
@@ -4,6 +4,7 @@ package provider
 import (
 	"context"
 	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -65,7 +66,7 @@ func resourceStackComponent() *schema.Resource {
 			"connector_id": {
 				Type:     schema.TypeString,
 				Optional: true,
-				// We cannot delete service connectors while they are still in 
+				// We cannot delete service connectors while they are still in
 				// use by a component, so we need to force new components when
 				// the connector is changed.
 				ForceNew: true,
@@ -98,7 +99,7 @@ func resourceStackComponentCreate(d *schema.ResourceData, m interface{}) error {
 	}
 
 	workspaceName := d.Get("workspace").(string)
-	
+
 	// Get the workspace ID
 	workspace, err := client.GetWorkspaceByName(workspaceName)
 	if err != nil {
@@ -107,7 +108,7 @@ func resourceStackComponentCreate(d *schema.ResourceData, m interface{}) error {
 
 	// Create the component request
 	component := ComponentRequest{
-		User:          user.ID,           // Add the user ID
+		User:          user.ID, // Add the user ID
 		Name:          d.Get("name").(string),
 		Type:          d.Get("type").(string),
 		Flavor:        d.Get("flavor").(string),
@@ -177,15 +178,16 @@ func resourceStackComponentRead(d *schema.ResourceData, m interface{}) error {
 	}
 
 	d.Set("name", component.Name)
-	
+
 	if component.Body != nil {
 		d.Set("type", component.Body.Type)
 		d.Set("flavor", component.Body.Flavor)
 	}
-	
+
 	if component.Metadata != nil {
 		d.Set("configuration", component.Metadata.Configuration)
-		if component.Metadata.Workspace != nil {
+
+		if component.Metadata.Workspace.Name != "default" {
 			d.Set("workspace", component.Metadata.Workspace.Name)
 		}
 		if component.Metadata.ConnectorResourceID != nil {
@@ -241,7 +243,6 @@ func resourceStackComponentUpdate(d *schema.ResourceData, m interface{}) error {
 	} else {
 		update.ConnectorID = nil
 	}
-
 
 	_, err := client.UpdateComponent(d.Id(), update)
 	if err != nil {

--- a/internal/provider/resource_stack_component.go
+++ b/internal/provider/resource_stack_component.go
@@ -44,10 +44,12 @@ func resourceStackComponent() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ValidateFunc: validation.StringInSlice(validComponentTypes, false),
+				ForceNew:     true,
 			},
 			"flavor": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 			"configuration": {
 				Type:      schema.TypeMap,
@@ -218,6 +220,8 @@ func resourceStackComponentUpdate(ctx context.Context, d *schema.ResourceData, m
 	update := ComponentUpdate{
 		Name: &name,
 	}
+
+	// type and flavor are immutable, so we don't need to check for changes
 
 	if d.HasChange("configuration") {
 		configMap := make(map[string]interface{})

--- a/internal/provider/resource_stack_component_test.go
+++ b/internal/provider/resource_stack_component_test.go
@@ -2,6 +2,7 @@
 package provider
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"testing"
@@ -98,7 +99,7 @@ func testAccCheckStackComponentExists(n string) resource.TestCheckFunc {
 		}
 
 		client := testAccProvider.Meta().(*Client)
-		_, err := client.GetComponent(rs.Primary.ID)
+		_, err := client.GetComponent(context.Background(), rs.Primary.ID)
 		if err != nil {
 			return fmt.Errorf("Stack Component not found: %v", err)
 		}
@@ -113,12 +114,12 @@ func testAccCheckStackComponentDestroy(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		switch rs.Type {
 		case "zenml_stack_component":
-			_, err := client.GetComponent(rs.Primary.ID)
+			_, err := client.GetComponent(context.Background(), rs.Primary.ID)
 			if err == nil {
 				return fmt.Errorf("Stack Component still exists")
 			}
 		case "zenml_service_connector":
-			_, err := client.GetServiceConnector(rs.Primary.ID)
+			_, err := client.GetServiceConnector(context.Background(), rs.Primary.ID)
 			if err == nil {
 				return fmt.Errorf("Service Connector still exists")
 			}

--- a/internal/provider/resource_stack_test.go
+++ b/internal/provider/resource_stack_test.go
@@ -1,11 +1,13 @@
 package provider
 
 import (
-	"testing"
+	"context"
 	"fmt"
+	"os"
+	"testing"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"os"
 )
 
 func TestAccStack_basic(t *testing.T) {
@@ -74,7 +76,7 @@ func testAccCheckStackExists(resourceName string) resource.TestCheckFunc {
 
 		// Add actual backend verification
 		client := testAccProvider.Meta().(*Client)
-		_, err := client.GetStack(rs.Primary.ID)
+		_, err := client.GetStack(context.Background(), rs.Primary.ID)
 		if err != nil {
 			return fmt.Errorf("error fetching stack with ID %s: %s", rs.Primary.ID, err)
 		}

--- a/internal/provider/validation.go
+++ b/internal/provider/validation.go
@@ -11,81 +11,73 @@ import (
 var (
 	validConnectorTypes = []string{
 		"aws", "gcp", "azure", "kubernetes",
-		"github", "gitlab", "bitbucket", "docker",
-		"mysql", "postgres", "snowflake", "databricks",
+		"docker", "hyperai",
 	}
 
-	validServiceTypes = map[string][]string{
+	validResourceTypes = map[string][]string{
 		"aws": {
-			"artifact-store",
-			"container-registry",
-			"secrets-manager",
-			"step-operator",
+			"aws-generic",
+			"s3-bucket",
+			"kubernetes-cluster",
+			"docker-registry",
 		},
 		"gcp": {
-			"artifact-store", 
-			"container-registry",
-			"secrets-manager",
-			"step-operator",
+			"gcp-generic",
+			"gcs-bucket",
+			"kubernetes-cluster",
+			"docker-registry",
 		},
 		"azure": {
-			"artifact-store",
-			"container-registry",
-			"step-operator",
+			"azure-generic",
+			"blob-container",
+			"kubernetes-cluster",
+			"docker-registry",
 		},
 		"kubernetes": {
-			"orchestrator",
-			"step-operator",
+			"kubernetes-cluster",
+		},
+		"docker": {
+			"docker-registry",
+		},
+		"hyperai": {
+			"hyperai-instance",
 		},
 	}
 
 	validAuthMethods = map[string][]string{
 		"aws": {
+			"implicit",
+			"secret-key",
 			"iam-role",
-			"aws-access-keys",
-			"web-identity",
+			"sts-token",
+			"session-token",
+			"federation-token",
 		},
 		"gcp": {
+			"implicit",
+			"user-account",
 			"service-account",
-			"oauth2",
-			"workload-identity",
+			"external-account",
+			"oauth2-token",
+			"impersonation",
 		},
 		"azure": {
+			"implicit",
 			"service-principal",
-			"managed-identity",
+			"access-token",
 		},
 		"kubernetes": {
-			"kubeconfig",
-			"service-account",
+			"password",
+			"token",
 		},
-	}
-
-	// Required configuration fields per connector type
-	requiredConfigFields = map[string][]string{
-		"aws":        {"region"},
-		"gcp":        {"project_id"},
-		"azure":      {"subscription_id", "tenant_id"},
-		"kubernetes": {"context"},
-	}
-
-	// Optional configuration fields per connector type
-	optionalConfigFields = map[string][]string{
-		"aws":        {"role_arn", "external_id", "session_name"},
-		"gcp":        {"zone", "location"},
-		"azure":      {"resource_group"},
-		"kubernetes": {"namespace", "cluster_name"},
-	}
-
-	// Required secrets per auth method
-	requiredSecrets = map[string]map[string][]string{
-		"aws": {
-			"aws-access-keys": {"aws_access_key_id", "aws_secret_access_key"},
+		"docker": {
+			"password",
 		},
-		"gcp": {
-			"service-account": {"service_account_json"},
-		},
-		"azure": {
-			"service-principal": {"client_id", "client_secret"},
+		"hyperai": {
+			"rsa-key",
+			"dsa-key",
+			"ecdsa-key",
+			"ed25519-key",
 		},
 	}
 
@@ -138,78 +130,30 @@ func validateServiceConnector(d *schema.ResourceDiff) error {
 		}
 	}
 
-	// Validate required configuration fields
-	if fields, ok := requiredConfigFields[connectorType]; ok {
-		config := d.Get("configuration").(map[string]interface{})
-		for _, field := range fields {
-			if _, ok := config[field]; !ok {
-				return fmt.Errorf("required configuration field %q missing for connector type %q",
-					field, connectorType)
+	// Validate resource type
+	if v, ok := d.GetOk("resource_type"); ok {
+		validTypes := validResourceTypes[connectorType]
+		resourceType := v.(string)
+		valid := false
+		for _, t := range validTypes {
+			if t == resourceType {
+				valid = true
+				break
 			}
+		}
+		if !valid {
+			return fmt.Errorf("invalid resource type %q for connector type %q. Valid types are: %s",
+				resourceType, connectorType, strings.Join(validTypes, ", "))
 		}
 	}
 
-	// Validate required secrets
-	if secretFields, ok := requiredSecrets[connectorType][authMethod]; ok {
-		secrets := d.Get("secrets").(map[string]interface{})
-		for _, field := range secretFields {
-			if _, ok := secrets[field]; !ok {
-				return fmt.Errorf("required secret %q missing for auth method %q",
-					field, authMethod)
-			}
-		}
-	}
-
-	// Validate resource types
-	if v, ok := d.GetOk("resource_types"); ok {
-		resourceTypes := v.(*schema.Set).List()
-		validTypes := getValidResourceTypes(connectorType)
-		for _, rt := range resourceTypes {
-			found := false
-			for _, vt := range validTypes {
-				if rt.(string) == vt {
-					found = true
-					break
-				}
-			}
-			if !found {
-				return fmt.Errorf("invalid resource type %q for connector type %q. Valid types are: %s",
-					rt.(string), connectorType, strings.Join(validTypes, ", "))
-			}
-		}
-	}
+	// NOTE: we specifically don't validate the configuration or secrets here
+	// for two reasons:
+	// 1. The configuration and secrets can be derived from resources and data
+	//    sources that are not available during plan time.
+	// 2. The configuration and secrets are validated by the ZenML server
+	//    when the connector is validated / created and we don't want to
+	//    duplicate that logic here.
 
 	return nil
-}
-
-func getValidResourceTypes(connectorType string) []string {
-	switch connectorType {
-	case "aws":
-		return []string{
-			"artifact-store",
-			"container-registry",
-			"step-operator",
-			"orchestrator",
-		}
-	case "gcp":
-		return []string{
-			"artifact-store",
-			"container-registry",
-			"step-operator",
-			"orchestrator",
-		}
-	case "azure":
-		return []string{
-			"artifact-store",
-			"container-registry",
-			"step-operator",
-		}
-	case "kubernetes":
-		return []string{
-			"orchestrator",
-			"step-operator",
-		}
-	default:
-		return []string{}
-	}
 }


### PR DESCRIPTION
This PR fixes a lot of bugs and makes improvements to the existing provider:

* allow using API tokens as well to authenticate
* cache API token internally in the client and regularly refresh it, if needed
* add a zenml_server data source to extract server info (e.g. version, server ID)
* only one optional `resource_type` can be configured for the service connector, to mimic the CLI UX
* verify service connector configurations before registering them, to catch authentication errors early
* handle unions of string and ServiceConnectorType object for the `connector_type` fields
* get rid of service connector secrets to keep the UX simple
* get rid of detailed service connector validation for configuration fields, to not duplicate the server verification functionality
* fix the data sources to allow fetching by ID as well as name+workspace
* get rid of stack description, as it's not implemented server-side
* add ForceNew in some places to avoid deleting stack components and service connectors that are referenced by stacks and stack components respectively
* fix the service connector validation to be aligned with currently supported resource types and authentication method options 
* fully migrate the provider code to the Terraform provider SDK v2
* add retry logic to handle transient service connector authorization errors that may happen while the accounting resources (e.g. IAM roles, GCP service accounts, permissions) propagate
* properly handle 404 HTTP errors (e.g. stack not found)
* add logging

NOTE: this version was successfully tested against various create/delete/update scenarios with a fully updated AWS ZenML Stack module: https://github.com/zenml-io/terraform-aws-zenml-stack/pull/1, a fully updated GCP ZenML Stack module: https://github.com/zenml-io/terraform-gcp-zenml-stack/pull/1 and a fully updated Azure ZenML Stack module: https://github.com/zenml-io/terraform-azure-zenml-stack/pull/1