### PR TITLE
Add support for ZenML projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,6 @@ resource "zenml_service_connector" "gcp" {
   name        = "gcp-connector"
   type        = "gcp"
   auth_method = "service-account"
-  # workspace defaults to "default" if not specified
   
   configuration = {
     project_id = "my-project"
@@ -130,7 +129,6 @@ resource "zenml_stack_component" "artifact_store" {
   name   = "gcs-store"
   type   = "artifact_store"
   flavor = "gcp"
-  # workspace defaults to "default" if not specified
   
   configuration = {
     path = "gs://my-bucket/artifacts"
@@ -146,7 +144,6 @@ resource "zenml_stack_component" "artifact_store" {
 # Create a stack using the components
 resource "zenml_stack" "ml_stack" {
   name = "production-stack"
-  # workspace defaults to "default" if not specified
   
   components = {
     artifact_store = zenml_stack_component.artifact_store.id
@@ -157,8 +154,6 @@ resource "zenml_stack" "ml_stack" {
   }
 }
 ```
-
-> **Note:** All resources support an optional `workspace` parameter that defaults to "default" if not specified. You can override this by setting `workspace = "your-workspace-name"` in any resource.
 
 See the [examples](./examples/) directory for more complete examples.
 

--- a/docs/data-sources/service_connector.md
+++ b/docs/data-sources/service_connector.md
@@ -28,7 +28,6 @@ The following arguments are supported:
 
 * `id` - (Optional) The ID of the service connector to retrieve. Either `id` or `name` must be provided.
 * `name` - (Optional) The name of the service connector to retrieve. Either `id` or `name` must be provided.
-* `workspace` - (Optional) The workspace ID to filter the service connector search. If not provided, the default workspace will be used.
 
 ## Attributes Reference
 
@@ -41,7 +40,6 @@ In addition to all arguments above, the following attributes are exported:
 * `resource_type` - The type of resource the service connector is connected to (e.g., "s3-bucket", "docker-registry", etc.).
 * `resource_id` - The ID of the resource the service connector is connected to.
 * `configuration` - A map of configuration key-value pairs for the service connector. Sensitive values are not included.
-* `workspace` - The workspace ID this service connector belongs to.
 * `labels` - A map of labels associated with this service connector.
 
 ## Import

--- a/docs/data-sources/stack_component.md
+++ b/docs/data-sources/stack_component.md
@@ -27,7 +27,6 @@ The following arguments are supported:
 
 * `id` - (Optional) The ID of the stack component to retrieve. Either `id` or `name` must be provided.
 * `name` - (Optional) The name of the stack component to retrieve. Either `id` or `name` must be provided.
-* `workspace` - (Optional) The workspace ID to filter the component search. If not provided, the default workspace will be used.
 
 ## Attributes Reference
 
@@ -38,7 +37,6 @@ In addition to all arguments above, the following attributes are exported:
 * `type` - The type of the stack component (e.g., "artifact_store", "orchestrator", etc.).
 * `flavor` - The flavor of the stack component (e.g., "local", "gcp", "aws", etc.).
 * `configuration` - A map of configuration key-value pairs for the stack component.
-* `workspace` - The workspace ID this stack component belongs to.
 * `labels` - A map of labels associated with this stack component.
 * `connector` - The ID of the service connector associated with this stack component.
 * `connector_resource_id` - The ID of the resource the service connector is connected to.

--- a/docs/resources/service_connector.md
+++ b/docs/resources/service_connector.md
@@ -16,7 +16,6 @@ resource "zenml_service_connector" "gcp_connector" {
   name        = "my-gcp-connector"
   type        = "gcp"
   auth_method = "service-account"
-  workspace   = "default"
   
   configuration = {
     project_id = "my-gcp-project"
@@ -48,7 +47,6 @@ resource "zenml_service_connector" "gcp_connector" {
   * GCP: `service-account`, `external-account`, `user-account`, `implicit`, `oauth2-token` or `impersonation`. Run `zenml service-connector describe-type gcp` or visit the [GCP Service Connector ZenML documentation page](https://docs.zenml.io/how-to/infrastructure-deployment/auth-management/gcp-service-connector) for more information.
   * Azure: `service-principal`, `access-token` or `implicit`. Run `zenml service-connector describe-type azure` or visit the [Azure Service Connector ZenML documentation page](https://docs.zenml.io/how-to/infrastructure-deployment/auth-management/azure-service-connector) for more information.
   * Kubernetes: `password` or `token`. Run `zenml service-connector describe-type kubernetes` or visit the [Kubernetes Service Connector ZenML documentation page](https://docs.zenml.io/how-to/infrastructure-deployment/auth-management/kubernetes-service-connector) for more information.
-* `workspace` - (Optional) The workspace this connector belongs to. Defaults to "default". Forces new resource if changed.
 * `resource_type` - (Optional) A resource type this connector can be used for (e.g., `s3-bucket`, `kubernetes-cluster`, `docker-registry`). To find out which resource types are supported by a connector, run `zenml service-connector describe-type <connector-type>`.
 * `configuration` - (Required, Sensitive) A map of configuration key-value pairs for the connector. Every authentication method has its own set of required and optional configuration parameters. To find out which parameters are required and optional for a given authentication method, run `zenml service-connector describe-type <connector-type> -a <auth-method>` or visit the [Service Connector ZenML documentation page](https://docs.zenml.io/how-to/infrastructure-deployment/auth-management) for the connector type and authentication method for more information.
 * `labels` - (Optional) A map of labels to associate with the connector.

--- a/docs/resources/stack.md
+++ b/docs/resources/stack.md
@@ -17,7 +17,6 @@ resource "zenml_stack_component" "artifact_store" {
   name      = "my-artifact-store"
   type      = "artifact_store"
   flavor    = "gcp"
-  workspace = "default"
   
   configuration = {
     path = "gs://my-bucket/artifacts"
@@ -28,7 +27,6 @@ resource "zenml_stack_component" "orchestrator" {
   name      = "my-orchestrator"
   type      = "orchestrator"
   flavor    = "kubernetes"
-  workspace = "default"
   
   configuration = {
     kubernetes_context = "my-k8s-cluster"
@@ -68,9 +66,6 @@ resource "zenml_stack" "my_stack" {
   * `feature_store`
   * `image_builder`
 * `labels` - (Optional) A map of labels to associate with the stack.
-* `workspace` - (Optional) The workspace to create the stack in. Defaults to "default". Forces new resource if changed.
-
--> **Note** If no workspace is specified, the stack will be created in the "default" workspace.
 
 ## Attributes Reference
 

--- a/docs/resources/stack_component.md
+++ b/docs/resources/stack_component.md
@@ -16,7 +16,6 @@ resource "zenml_stack_component" "artifact_store" {
   name      = "my-artifact-store"
   type      = "artifact_store"
   flavor    = "gcp"
-  workspace = "default"
   
   configuration = {
     path = "gs://my-bucket/artifacts"
@@ -49,7 +48,6 @@ resource "zenml_stack_component" "artifact_store" {
   * `step_operator` - Step operator
   * `model_registry` - Model registry
 * `flavor` - (Required) The flavor of the stack component (e.g., "local", "gcp", "aws"). To find out which flavors are supported by a component type, run `zenml stack-component describe-type <component-type>` or visit the [Component Gallery section of the ZenML documentation](https://docs.zenml.io/stack-components/component-guide) for more information.
-* `workspace` - (Required, Forces new resource) The name of the workspace this component belongs to.
 * `configuration` - (Optional, Sensitive) A map of configuration key-value pairs for the component.
 * `connector_id` - (Optional) The ID of the service connector to use with this component. Must be specified together with `connector_resource_id`.
 * `connector_resource_id` - (Optional) The ID of the connector resource to use with this component. Must be specified together with `connector_id`.

--- a/examples/data-sources/main.tf
+++ b/examples/data-sources/main.tf
@@ -15,20 +15,17 @@ provider "zenml" {
 # Look up an existing stack by name
 data "zenml_stack" "existing" {
   name      = "production-stack"
-  workspace = var.workspace_id
 }
 
 # Look up a stack component
 data "zenml_stack_component" "artifact_store" {
   name      = "production-artifact-store"
-  workspace = var.workspace_id
   type      = "artifact_store"
 }
 
 # Look up a service connector
 data "zenml_service_connector" "gcp" {
   name      = "production-gcp"
-  workspace = var.workspace_id
 }
 
 # Use the existing resources to create a new stack

--- a/examples/data-sources/variables.tf
+++ b/examples/data-sources/variables.tf
@@ -7,7 +7,3 @@ variable "zenml_api_key" {
   type      = string
   sensitive = true
 }
-
-variable "workspace_id" {
-  type = string
-}

--- a/internal/provider/client.go
+++ b/internal/provider/client.go
@@ -190,8 +190,8 @@ func (c *Client) GetServerInfo(ctx context.Context) (*ServerInfo, error) {
 }
 
 // Stack operations
-func (c *Client) CreateStack(ctx context.Context, workspace string, stack StackRequest) (*StackResponse, error) {
-	endpoint := fmt.Sprintf("/api/v1/workspaces/%s/stacks", workspace)
+func (c *Client) CreateStack(ctx context.Context, stack StackRequest) (*StackResponse, error) {
+	endpoint := "/api/v1/stacks"
 	resp, _, err := c.doRequest(ctx, "POST", endpoint, stack)
 	if err != nil {
 		return nil, err
@@ -289,8 +289,8 @@ func (c *Client) ListStacks(ctx context.Context, params *ListParams) (*Page[Stac
 }
 
 // Component operations...
-func (c *Client) CreateComponent(ctx context.Context, workspace string, component ComponentRequest) (*ComponentResponse, error) {
-	endpoint := fmt.Sprintf("/api/v1/workspaces/%s/components", workspace)
+func (c *Client) CreateComponent(ctx context.Context, component ComponentRequest) (*ComponentResponse, error) {
+	endpoint := "/api/v1/components"
 	resp, _, err := c.doRequest(ctx, "POST", endpoint, component)
 	if err != nil {
 		return nil, err
@@ -349,7 +349,7 @@ func (c *Client) DeleteComponent(ctx context.Context, id string) error {
 	return nil
 }
 
-func (c *Client) ListStackComponents(ctx context.Context, workspace string, params *ListParams) (*Page[ComponentResponse], error) {
+func (c *Client) ListStackComponents(ctx context.Context, params *ListParams) (*Page[ComponentResponse], error) {
 	if params == nil {
 		params = &ListParams{
 			Page:     1,
@@ -371,7 +371,7 @@ func (c *Client) ListStackComponents(ctx context.Context, workspace string, para
 		query.Add(k, v)
 	}
 
-	path := fmt.Sprintf("/api/v1/workspaces/%s/components?%s", workspace, query.Encode())
+	path := fmt.Sprintf("/api/v1/components?%s", query.Encode())
 	resp, _, err := c.doRequest(ctx, "GET", path, nil)
 	if err != nil {
 		return nil, err
@@ -401,8 +401,8 @@ func (c *Client) VerifyServiceConnector(ctx context.Context, connector ServiceCo
 	return &result, nil
 }
 
-func (c *Client) CreateServiceConnector(ctx context.Context, workspace string, connector ServiceConnectorRequest) (*ServiceConnectorResponse, error) {
-	endpoint := fmt.Sprintf("/api/v1/workspaces/%s/service_connectors", workspace)
+func (c *Client) CreateServiceConnector(ctx context.Context, connector ServiceConnectorRequest) (*ServiceConnectorResponse, error) {
+	endpoint := "/api/v1/service_connectors"
 	resp, _, err := c.doRequest(ctx, "POST", endpoint, connector)
 	if err != nil {
 		return nil, err
@@ -500,11 +500,10 @@ func (c *Client) ListServiceConnectors(ctx context.Context, params *ListParams) 
 }
 
 // Add this new method to the Client
-func (c *Client) GetServiceConnectorByName(ctx context.Context, workspace, name string) (*ServiceConnectorResponse, error) {
+func (c *Client) GetServiceConnectorByName(ctx context.Context, name string) (*ServiceConnectorResponse, error) {
 	params := &ListParams{
 		Filter: map[string]string{
-			"name":      name,
-			"workspace": workspace,
+			"name": name,
 		},
 	}
 
@@ -521,18 +520,18 @@ func (c *Client) GetServiceConnectorByName(ctx context.Context, workspace, name 
 }
 
 // Add this new method to the Client
-func (c *Client) GetWorkspaceByName(ctx context.Context, name string) (*WorkspaceResponse, error) {
-	resp, status, err := c.doRequest(ctx, "GET", fmt.Sprintf("/api/v1/workspaces/%s", name), nil)
+func (c *Client) GetProjectByName(ctx context.Context, name string) (*ProjectResponse, error) {
+	resp, status, err := c.doRequest(ctx, "GET", fmt.Sprintf("/api/v1/projects/%s", name), nil)
 	if err != nil {
 		if status == 404 {
-			// Return nil if the workspace is not found
+			// Return nil if the project is not found
 			return nil, nil
 		}
 		return nil, err
 	}
 	defer resp.Body.Close()
 
-	var result WorkspaceResponse
+	var result ProjectResponse
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		return nil, fmt.Errorf("error decoding response: %v", err)
 	}

--- a/internal/provider/data_source_service_connector.go
+++ b/internal/provider/data_source_service_connector.go
@@ -19,12 +19,6 @@ func dataSourceServiceConnector() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 			},
-			"workspace": {
-				Description: "Name of the workspace (defaults to 'default')",
-				Type:        schema.TypeString,
-				Optional:    true,
-				Default:     "default",
-			},
 			"name": {
 				Description: "Name of the service connector",
 				Type:        schema.TypeString,
@@ -89,7 +83,6 @@ func dataSourceServiceConnector() *schema.Resource {
 func dataSourceServiceConnectorRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	c := m.(*Client)
 
-	workspace := d.Get("workspace").(string)
 	name := d.Get("name").(string)
 	id := d.Get("id").(string)
 
@@ -99,7 +92,7 @@ func dataSourceServiceConnectorRead(ctx context.Context, d *schema.ResourceData,
 	if id != "" {
 		connector, err = c.GetServiceConnector(ctx, id)
 	} else if name != "" {
-		connector, err = c.GetServiceConnectorByName(ctx, workspace, name)
+		connector, err = c.GetServiceConnectorByName(ctx, name)
 	} else {
 		return diag.FromErr(fmt.Errorf("either 'id' or 'name' must be set"))
 	}
@@ -178,10 +171,6 @@ func dataSourceServiceConnectorRead(ctx context.Context, d *schema.ResourceData,
 	}
 
 	if connector.Metadata != nil {
-		if err := d.Set("workspace", connector.Metadata.Workspace.Name); err != nil {
-			return diag.FromErr(err)
-		}
-
 		if err := d.Set("configuration", connector.Metadata.Configuration); err != nil {
 			return diag.FromErr(err)
 		}

--- a/internal/provider/data_source_stack.go
+++ b/internal/provider/data_source_stack.go
@@ -19,12 +19,6 @@ func dataSourceStack() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 			},
-			"workspace": {
-				Description: "Name of the workspace (defaults to 'default')",
-				Type:        schema.TypeString,
-				Optional:    true,
-				Default:     "default",
-			},
 			"name": {
 				Description: "Name of the stack",
 				Type:        schema.TypeString,
@@ -81,7 +75,6 @@ func dataSourceStackRead(ctx context.Context, d *schema.ResourceData, m interfac
 	c := m.(*Client)
 
 	id := d.Get("id").(string)
-	workspace := d.Get("workspace").(string)
 	name := d.Get("name").(string)
 
 	var stack *StackResponse = nil
@@ -97,8 +90,7 @@ func dataSourceStackRead(ctx context.Context, d *schema.ResourceData, m interfac
 		// List stacks with filter to find by name
 		params := &ListParams{
 			Filter: map[string]string{
-				"name":      name,
-				"workspace": workspace,
+				"name": name,
 			},
 		}
 
@@ -108,7 +100,7 @@ func dataSourceStackRead(ctx context.Context, d *schema.ResourceData, m interfac
 		}
 
 		if len(stacks.Items) == 0 {
-			return diag.FromErr(fmt.Errorf("no stack found with name %s in workspace %s", name, workspace))
+			return diag.FromErr(fmt.Errorf("no stack found with name %s", name))
 		}
 
 		stack = &stacks.Items[0]

--- a/internal/provider/data_source_stack_component.go
+++ b/internal/provider/data_source_stack_component.go
@@ -20,12 +20,6 @@ func dataSourceStackComponent() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 			},
-			"workspace": {
-				Description: "Name of the workspace (defaults to 'default')",
-				Type:        schema.TypeString,
-				Optional:    true,
-				Default:     "default",
-			},
 			"name": {
 				Description: "Name of the stack component",
 				Type:        schema.TypeString,
@@ -126,7 +120,6 @@ func dataSourceStackComponentRead(ctx context.Context, d *schema.ResourceData, m
 	c := m.(*Client)
 
 	id := d.Get("id").(string)
-	workspace := d.Get("workspace").(string)
 	name := d.Get("name").(string)
 	componentType := d.Get("type").(string)
 
@@ -142,20 +135,19 @@ func dataSourceStackComponentRead(ctx context.Context, d *schema.ResourceData, m
 		// List components with filters
 		params := &ListParams{
 			Filter: map[string]string{
-				"name":      name,
-				"workspace": workspace,
-				"type":      componentType,
+				"name": name,
+				"type": componentType,
 			},
 		}
 
-		components, err := c.ListStackComponents(ctx, workspace, params)
+		components, err := c.ListStackComponents(ctx, params)
 		if err != nil {
 			return diag.FromErr(fmt.Errorf("error listing stack components: %v", err))
 		}
 
 		if len(components.Items) == 0 {
-			return diag.FromErr(fmt.Errorf("no component found with name %s and type %s in workspace %s",
-				name, componentType, workspace))
+			return diag.FromErr(fmt.Errorf("no component found with name %s and type %s",
+				name, componentType))
 		}
 
 		component = &components.Items[0]

--- a/internal/provider/models.go
+++ b/internal/provider/models.go
@@ -7,11 +7,11 @@ import (
 
 // Page represents a paginated response from the API
 type Page[T any] struct {
-	Index      int   `json:"index"`
-	MaxSize    int   `json:"max_size"`
-	TotalPages int   `json:"total_pages"`
-	Total      int   `json:"total"`
-	Items      []T   `json:"items"`
+	Index      int `json:"index"`
+	MaxSize    int `json:"max_size"`
+	TotalPages int `json:"total_pages"`
+	Total      int `json:"total"`
+	Items      []T `json:"items"`
 }
 
 // APIError represents an error response from the API
@@ -25,199 +25,192 @@ func (e *APIError) Error() string {
 
 // ServerInfo represents the server information response from the API
 type ServerInfo struct {
-	ID       		string     `json:"id"`
-	Name     		string     `json:"name"`
-	Version  		string     `json:"version"`
-	DeploymentType  string	   `json:"deployment_type"`
-	AuthScheme  	string     `json:"auth_scheme"`
-	ServerURL 		string     `json:"server_url"`
-	DashboardURL 	string     `json:"dashboard_url"`
-	Metadata 		map[string]string `json:"metadata"`
+	ID             string            `json:"id"`
+	Name           string            `json:"name"`
+	Version        string            `json:"version"`
+	DeploymentType string            `json:"deployment_type"`
+	AuthScheme     string            `json:"auth_scheme"`
+	ServerURL      string            `json:"server_url"`
+	DashboardURL   string            `json:"dashboard_url"`
+	Metadata       map[string]string `json:"metadata"`
 }
 
 // StackRequest represents a request to create a new stack
 type StackRequest struct {
-	Name        string                     `json:"name"`
-	Components  map[string][]string        `json:"components"`          // Change to UUID strings
-	Labels 		map[string]string          `json:"labels"`
+	Name       string              `json:"name"`
+	Components map[string][]string `json:"components"` // Change to UUID strings
+	Labels     map[string]string   `json:"labels"`
 }
 
 // StackResponse represents a stack response from the API
 type StackResponse struct {
-	ID       string                `json:"id"`
-	Name     string                `json:"name"`
-	Body     *StackResponseBody    `json:"body,omitempty"`
+	ID       string                 `json:"id"`
+	Name     string                 `json:"name"`
+	Body     *StackResponseBody     `json:"body,omitempty"`
 	Metadata *StackResponseMetadata `json:"metadata,omitempty"`
 }
 
 type StackResponseBody struct {
-	Created string      `json:"created"`
-	Updated string      `json:"updated"`
+	Created string        `json:"created"`
+	Updated string        `json:"updated"`
 	User    *UserResponse `json:"user,omitempty"`
 }
 
 type StackResponseMetadata struct {
-	Workspace     *WorkspaceResponse              `json:"workspace"`
-	Components    map[string][]ComponentResponse  `json:"components"`
-	Labels        map[string]string               `json:"labels,omitempty"`
+	Components map[string][]ComponentResponse `json:"components"`
+	Labels     map[string]string              `json:"labels,omitempty"`
 }
 
 // StackUpdate represents an update to an existing stack
 type StackUpdate struct {
-	Name          *string                        `json:"name,omitempty"`
-	Components    map[string][]string            `json:"components,omitempty"`    // Only UUIDs for updates
-	Labels        map[string]string              `json:"labels,omitempty"`
+	Name       *string             `json:"name,omitempty"`
+	Components map[string][]string `json:"components,omitempty"` // Only UUIDs for updates
+	Labels     map[string]string   `json:"labels,omitempty"`
 }
 
 // ComponentRequest represents a request to create a new component
 type ComponentRequest struct {
-	User              string                     `json:"user"`
-	Workspace         string                     `json:"workspace"`
-	Name              string                     `json:"name"`
-	Type              string                     `json:"type"`
-	Flavor            string                     `json:"flavor"`
-	Configuration     map[string]interface{}     `json:"configuration"`
-	ConnectorID       *string                    `json:"connector,omitempty"`
-	ConnectorResourceID *string                  `json:"connector_resource_id,omitempty"`
-	Labels            map[string]string          `json:"labels,omitempty"`
+	User                string                 `json:"user"`
+	Name                string                 `json:"name"`
+	Type                string                 `json:"type"`
+	Flavor              string                 `json:"flavor"`
+	Configuration       map[string]interface{} `json:"configuration"`
+	ConnectorID         *string                `json:"connector,omitempty"`
+	ConnectorResourceID *string                `json:"connector_resource_id,omitempty"`
+	Labels              map[string]string      `json:"labels,omitempty"`
 }
 
 // ComponentResponse represents a stack component response from the API
 type ComponentResponse struct {
-	ID       string                    `json:"id"`
-	Name     string                    `json:"name"`
-	Body     *ComponentResponseBody    `json:"body,omitempty"`
+	ID       string                     `json:"id"`
+	Name     string                     `json:"name"`
+	Body     *ComponentResponseBody     `json:"body,omitempty"`
 	Metadata *ComponentResponseMetadata `json:"metadata,omitempty"`
 }
 
 type ComponentResponseBody struct {
-	Created    string                  `json:"created"`
-	Updated    string                  `json:"updated"`
-	User       *UserResponse           `json:"user,omitempty"`
-	Type       string                  `json:"type"`
-	Flavor     string                  `json:"flavor_name"`
-	Integration *string                `json:"integration,omitempty"`
+	Created     string        `json:"created"`
+	Updated     string        `json:"updated"`
+	User        *UserResponse `json:"user,omitempty"`
+	Type        string        `json:"type"`
+	Flavor      string        `json:"flavor_name"`
+	Integration *string       `json:"integration,omitempty"`
 }
 
 type ComponentResponseMetadata struct {
-	Workspace           *WorkspaceResponse       `json:"workspace"`
-	Configuration       map[string]interface{}   `json:"configuration"`
-	Labels              map[string]string        `json:"labels,omitempty"`
-	ConnectorResourceID *string                  `json:"connector_resource_id,omitempty"`
-	Connector          *ServiceConnectorResponse `json:"connector,omitempty"`
+	Configuration       map[string]interface{}    `json:"configuration"`
+	Labels              map[string]string         `json:"labels,omitempty"`
+	ConnectorResourceID *string                   `json:"connector_resource_id,omitempty"`
+	Connector           *ServiceConnectorResponse `json:"connector,omitempty"`
 }
 
 // ComponentUpdate represents an update to an existing component
 type ComponentUpdate struct {
-	Name               *string                   `json:"name,omitempty"`
-	Type               *string                   `json:"type,omitempty"`
-	Flavor             *string                   `json:"flavor,omitempty"`
-	Configuration      map[string]interface{}    `json:"configuration,omitempty"`
-	ConnectorID        *string                   `json:"connector,omitempty"`
-	ConnectorResourceID *string                  `json:"connector_resource_id,omitempty"`
-	Labels             map[string]string         `json:"labels,omitempty"`
+	Name                *string                `json:"name,omitempty"`
+	Type                *string                `json:"type,omitempty"`
+	Flavor              *string                `json:"flavor,omitempty"`
+	Configuration       map[string]interface{} `json:"configuration,omitempty"`
+	ConnectorID         *string                `json:"connector,omitempty"`
+	ConnectorResourceID *string                `json:"connector_resource_id,omitempty"`
+	Labels              map[string]string      `json:"labels,omitempty"`
 }
 
 // ServiceConnectorRequest represents a request to create a new service connector
 type ServiceConnectorRequest struct {
-	User           string                        `json:"user"`
-	Workspace      string                        `json:"workspace"`
-	Name           string                        `json:"name"`
-	ConnectorType  string                        `json:"connector_type"`
-	AuthMethod     string                        `json:"auth_method"`
-	ResourceTypes  []string                      `json:"resource_types"`
-	Configuration  map[string]interface{}        `json:"configuration"`
-	Secrets        map[string]string             `json:"secrets,omitempty"`
-	Labels         map[string]string             `json:"labels,omitempty"`
-	ResourceID     *string                       `json:"resource_id,omitempty"`
-	ExpiresAt      *string                       `json:"expires_at,omitempty"`
+	User          string                 `json:"user"`
+	Name          string                 `json:"name"`
+	ConnectorType string                 `json:"connector_type"`
+	AuthMethod    string                 `json:"auth_method"`
+	ResourceTypes []string               `json:"resource_types"`
+	Configuration map[string]interface{} `json:"configuration"`
+	Secrets       map[string]string      `json:"secrets,omitempty"`
+	Labels        map[string]string      `json:"labels,omitempty"`
+	ResourceID    *string                `json:"resource_id,omitempty"`
+	ExpiresAt     *string                `json:"expires_at,omitempty"`
 }
 
 type ServiceConnectorResourceType struct {
-    Name		   string                        `json:"name"`
-	ResourceType   string                        `json:"resource_type"`
-	Description	   string                        `json:"description"`
-	AuthMethods    []string                      `json:"auth_methods"`
-	SupportsInstances bool                       `json:"supports_instances"`
+	Name              string   `json:"name"`
+	ResourceType      string   `json:"resource_type"`
+	Description       string   `json:"description"`
+	AuthMethods       []string `json:"auth_methods"`
+	SupportsInstances bool     `json:"supports_instances"`
 }
 
 type ServiceConnectorAuthenticationMethod struct {
-    Name		   string                        `json:"name"`
-	AuthMethod	 string                        `json:"auth_method"`
-	Description	 string                        `json:"description"`
+	Name        string `json:"name"`
+	AuthMethod  string `json:"auth_method"`
+	Description string `json:"description"`
 }
 
 type ServiceConnectorType struct {
-    Name		   string                        `json:"name"`
-	ConnectorType  string                        `json:"connector_type"`
-	Description	   string                        `json:"description"`
-	ResourceTypes  []ServiceConnectorResourceType `json:"resource_types"`
-	AuthMethods    []ServiceConnectorAuthenticationMethod `json:"auth_methods"`
+	Name          string                                 `json:"name"`
+	ConnectorType string                                 `json:"connector_type"`
+	Description   string                                 `json:"description"`
+	ResourceTypes []ServiceConnectorResourceType         `json:"resource_types"`
+	AuthMethods   []ServiceConnectorAuthenticationMethod `json:"auth_methods"`
 }
 
 // ServiceConnectorResponse represents a service connector response from the API
 type ServiceConnectorResponse struct {
-	ID          string                           `json:"id"`
-	Name        string                           `json:"name"`
-	Body        *ServiceConnectorResponseBody    `json:"body,omitempty"`
-	Metadata    *ServiceConnectorResponseMetadata `json:"metadata,omitempty"`
+	ID       string                            `json:"id"`
+	Name     string                            `json:"name"`
+	Body     *ServiceConnectorResponseBody     `json:"body,omitempty"`
+	Metadata *ServiceConnectorResponseMetadata `json:"metadata,omitempty"`
 }
 
 type ServiceConnectorResponseBody struct {
-	Created        string                        `json:"created"`
-	Updated        string                        `json:"updated"`
-	User           *UserResponse                 `json:"user,omitempty"`
-    ConnectorType  json.RawMessage               `json:"connector_type"` // Can be string or ServiceConnectorType
-	AuthMethod     string                        `json:"auth_method"`
-	ResourceTypes  []string                      `json:"resource_types"`
-	ResourceID     *string                       `json:"resource_id,omitempty"`
-	ExpiresAt      *string                       `json:"expires_at,omitempty"`
+	Created       string          `json:"created"`
+	Updated       string          `json:"updated"`
+	User          *UserResponse   `json:"user,omitempty"`
+	ConnectorType json.RawMessage `json:"connector_type"` // Can be string or ServiceConnectorType
+	AuthMethod    string          `json:"auth_method"`
+	ResourceTypes []string        `json:"resource_types"`
+	ResourceID    *string         `json:"resource_id,omitempty"`
+	ExpiresAt     *string         `json:"expires_at,omitempty"`
 }
 
 type ServiceConnectorResponseMetadata struct {
-	Workspace      *WorkspaceResponse            `json:"workspace"`
-	Configuration  map[string]interface{}        `json:"configuration"`
-	SecretID       *string                       `json:"secret_id,omitempty"`
-	Labels         map[string]string             `json:"labels,omitempty"`
+	Configuration map[string]interface{} `json:"configuration"`
+	SecretID      *string                `json:"secret_id,omitempty"`
+	Labels        map[string]string      `json:"labels,omitempty"`
 }
-
 
 // ServiceConnectorResources represents a service connector resources response
 // from the API
 type ServiceConnectorResources struct {
-	ID          string                           `json:"id"`
-	Name        string                           `json:"name"`
-    ConnectorType  json.RawMessage               `json:"connector_type"` // Can be string or ServiceConnectorType
-	Resources   []ServiceConnectorTypedResources `json:"resources"`
-	Error	   *string                           `json:"error,omitempty"`
+	ID            string                           `json:"id"`
+	Name          string                           `json:"name"`
+	ConnectorType json.RawMessage                  `json:"connector_type"` // Can be string or ServiceConnectorType
+	Resources     []ServiceConnectorTypedResources `json:"resources"`
+	Error         *string                          `json:"error,omitempty"`
 }
 
 type ServiceConnectorTypedResources struct {
-	ResourceType  string                        `json:"resource_type"`
-	ResourceIDs   []string                      `json:"resource_ids"`
-	Error         *string                       `json:"error,omitempty"`
+	ResourceType string   `json:"resource_type"`
+	ResourceIDs  []string `json:"resource_ids"`
+	Error        *string  `json:"error,omitempty"`
 }
-
 
 // ServiceConnectorUpdate represents an update to an existing service connector
 type ServiceConnectorUpdate struct {
-	Name           *string                       `json:"name,omitempty"`
-	Configuration  map[string]interface{}        `json:"configuration,omitempty"`
-	Secrets        map[string]string             `json:"secrets,omitempty"`
-	Labels         map[string]string             `json:"labels,omitempty"`
-	ResourceTypes  []string                      `json:"resource_types"`
-	ResourceID     *string                       `json:"resource_id,omitempty"`
-	ExpiresAt      *string                       `json:"expires_at,omitempty"`
+	Name          *string                `json:"name,omitempty"`
+	Configuration map[string]interface{} `json:"configuration,omitempty"`
+	Secrets       map[string]string      `json:"secrets,omitempty"`
+	Labels        map[string]string      `json:"labels,omitempty"`
+	ResourceTypes []string               `json:"resource_types"`
+	ResourceID    *string                `json:"resource_id,omitempty"`
+	ExpiresAt     *string                `json:"expires_at,omitempty"`
 }
 
 // UserResponse represents a user response from the API
 type UserResponse struct {
-	ID               string           `json:"id"`
-	Name             string           `json:"name"`
-	Body             *UserResponseBody `json:"body,omitempty"`
+	ID               string                `json:"id"`
+	Name             string                `json:"name"`
+	Body             *UserResponseBody     `json:"body,omitempty"`
 	Metadata         *UserResponseMetadata `json:"metadata,omitempty"`
-	Resources        interface{}      `json:"resources"`
-	PermissionDenied bool             `json:"permission_denied"`
+	Resources        interface{}           `json:"resources"`
+	PermissionDenied bool                  `json:"permission_denied"`
 }
 
 type UserResponseBody struct {
@@ -232,24 +225,25 @@ type UserResponseBody struct {
 }
 
 type UserResponseMetadata struct {
-	Email           *string         `json:"email"`
-	ExternalUserID  *string         `json:"external_user_id"`
-	UserMetadata    UserMetadata    `json:"user_metadata"`
+	Email          *string      `json:"email"`
+	ExternalUserID *string      `json:"external_user_id"`
+	UserMetadata   UserMetadata `json:"user_metadata"`
 }
 
 type UserMetadata struct {
-	PrimaryUse             string   `json:"primary_use"`
-	UsageReason           string   `json:"usage_reason"`
-	InfraProviders        []string `json:"infra_providers"`
-	FinishedOnboardingSurvey bool  `json:"finished_onboarding_survey"`
-	OverviewTourDone      bool     `json:"overview_tour_done"`
+	PrimaryUse               string   `json:"primary_use"`
+	UsageReason              string   `json:"usage_reason"`
+	InfraProviders           []string `json:"infra_providers"`
+	FinishedOnboardingSurvey bool     `json:"finished_onboarding_survey"`
+	OverviewTourDone         bool     `json:"overview_tour_done"`
 }
 
-// WorkspaceResponse represents a workspace response from the API
-type WorkspaceResponse struct {
-	ID          string    `json:"id"`
-	Name        string    `json:"name"`
-	Description string    `json:"description,omitempty"`
-	Created     string    `json:"created"`
-	Updated     string    `json:"updated"`
+// ProjectResponse represents a project response from the API
+type ProjectResponse struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	DisplayName string `json:"display_name"`
+	Description string `json:"description,omitempty"`
+	Created     string `json:"created"`
+	Updated     string `json:"updated"`
 }

--- a/internal/provider/resource_service_connector_test.go
+++ b/internal/provider/resource_service_connector_test.go
@@ -4,7 +4,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -113,16 +112,11 @@ func testAccCheckServiceConnectorDestroy(s *terraform.State) error {
 }
 
 func testAccServiceConnectorConfig_basic() string {
-	workspace := os.Getenv("ZENML_WORKSPACE")
-	if workspace == "" {
-		workspace = "default"
-	}
-	return fmt.Sprintf(`
+	return `
 resource "zenml_service_connector" "test" {
 	name        = "test-connector"
 	type        = "gcp"
 	auth_method = "service-account"
-	workspace   = "%s"
 	
 	resource_type = "gcs-bucket"
 	
@@ -137,21 +131,15 @@ resource "zenml_service_connector" "test" {
 	labels = {
 		environment = "test"
 	}
-}
-`, workspace)
+}`
 }
 
 func testAccServiceConnectorConfig_update() string {
-	workspace := os.Getenv("ZENML_WORKSPACE")
-	if workspace == "" {
-		workspace = "default"
-	}
-	return fmt.Sprintf(`
+	return `
 resource "zenml_service_connector" "test" {
 	name        = "updated-connector"
 	type        = "gcp"
 	auth_method = "service-account"
-	workspace   = "%s"
 		
 	configuration = {
 		project_id = "test-project"
@@ -166,6 +154,5 @@ resource "zenml_service_connector" "test" {
 		environment = "staging"
 		team        = "ml"
 	}
-}
-`, workspace)
+}`
 }

--- a/internal/provider/resource_stack.go
+++ b/internal/provider/resource_stack.go
@@ -18,12 +18,6 @@ func resourceStack() *schema.Resource {
 		DeleteContext: resourceStackDelete,
 
 		Schema: map[string]*schema.Schema{
-			"workspace": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  "default",
-				ForceNew: true,
-			},
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -80,9 +74,6 @@ func resourceStack() *schema.Resource {
 func resourceStackCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*Client)
 
-	// Get the workspace from schema instead of hardcoding
-	workspace := d.Get("workspace").(string)
-
 	stack := StackRequest{
 		Name: d.Get("name").(string),
 	}
@@ -106,7 +97,7 @@ func resourceStackCreate(ctx context.Context, d *schema.ResourceData, m interfac
 		stack.Labels = labels
 	}
 
-	resp, err := client.CreateStack(ctx, workspace, stack)
+	resp, err := client.CreateStack(ctx, stack)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error creating stack: %w", err))
 	}
@@ -144,10 +135,6 @@ func resourceStackRead(ctx context.Context, d *schema.ResourceData, m interface{
 
 	// Handle labels if present
 	if stack.Metadata != nil && stack.Metadata.Labels != nil {
-
-		if stack.Metadata.Workspace.Name != "default" {
-			d.Set("workspace", stack.Metadata.Workspace.Name)
-		}
 
 		d.Set("labels", stack.Metadata.Labels)
 	}

--- a/internal/provider/resource_stack_component_test.go
+++ b/internal/provider/resource_stack_component_test.go
@@ -4,7 +4,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -130,17 +129,11 @@ func testAccCheckStackComponentDestroy(s *terraform.State) error {
 }
 
 func testAccStackComponentConfig_basic() string {
-	workspace := os.Getenv("ZENML_WORKSPACE")
-	if workspace == "" {
-		workspace = "default"
-	}
-
-	return fmt.Sprintf(`
+	return `
 resource "zenml_stack_component" "test" {
 	name      = "test-store"
 	type      = "artifact_store"
 	flavor    = "local"
-	workspace = "%s"
 	
 	configuration = {
 		path = "/tmp/artifacts"
@@ -149,22 +142,15 @@ resource "zenml_stack_component" "test" {
 	labels = {
 		environment = "test"
 	}
-}
-`, workspace)
+}`
 }
 
 func testAccStackComponentConfig_update() string {
-	workspace := os.Getenv("ZENML_WORKSPACE")
-	if workspace == "" {
-		workspace = "default"
-	}
-
-	return fmt.Sprintf(`
+	return `
 resource "zenml_stack_component" "test" {
 	name      = "updated-store"
 	type      = "artifact_store"
 	flavor    = "local"
-	workspace = "%s"
 	
 	configuration = {
 		path = "/tmp/artifacts-updated"
@@ -174,21 +160,15 @@ resource "zenml_stack_component" "test" {
 		environment = "staging"
 		team        = "ml"
 	}
-}
-`, workspace)
+}`
 }
 
 func testAccStackComponentConfig_withConnector() string {
-	workspace := os.Getenv("ZENML_WORKSPACE")
-	if workspace == "" {
-		workspace = "default"
-	}
-	return fmt.Sprintf(`
+	return `
 resource "zenml_service_connector" "test" {
 	name        = "test-connector"
 	type        = "gcp"
 	auth_method = "service-account"
-	workspace = "%s"
 	
 	resource_type = "gcs-bucket"
 	
@@ -205,7 +185,6 @@ resource "zenml_stack_component" "test" {
 	name      = "test-store"
 	type      = "artifact_store"
 	flavor    = "gcp"
-	workspace = "%s"
 	
 	configuration = {
 		path = "gs://test-bucket/artifacts"
@@ -216,6 +195,5 @@ resource "zenml_stack_component" "test" {
 	labels = {
 		environment = "test"
 	}
-}
-`, workspace, workspace)
+}`
 }

--- a/internal/provider/resource_stack_test.go
+++ b/internal/provider/resource_stack_test.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -29,17 +28,11 @@ func TestAccStack_basic(t *testing.T) {
 }
 
 func testAccStackConfig_basic() string {
-	workspace := os.Getenv("ZENML_WORKSPACE")
-	if workspace == "" {
-		workspace = "default"
-	}
-
-	return fmt.Sprintf(`
+	return `
 resource "zenml_stack_component" "artifact_store" {
     name      = "test-store"
     type      = "artifact_store"
     flavor    = "local"
-    workspace = "%s"
     
     configuration = {
         path = "/tmp/artifacts"
@@ -48,7 +41,6 @@ resource "zenml_stack_component" "artifact_store" {
 
 resource "zenml_stack" "test" {
     name      = "test-stack"
-    workspace = "%s"
     
     components = {
         "artifact_store" = zenml_stack_component.artifact_store.id
@@ -57,8 +49,7 @@ resource "zenml_stack" "test" {
     labels = {
         environment = "test"
     }
-}
-`, workspace, workspace)
+}`
 }
 
 func testAccCheckStackDestroy(s *terraform.State) error {


### PR DESCRIPTION
Adds support for the 0.80.0 ZenML release, particularly for the ZenML Projects (ex: workspace) feature:

* removes any mention of workspaces from stack, components and service connector models
* adds a check that shows a user-friendly error if this provider version is used with ZenML < 0.80.0, instructing users on how to proceed.

![image](https://github.com/user-attachments/assets/19c9be63-4472-48da-bd54-6fdfe1224f0c)
