### PR TITLE
Fix missing user in service connector response body

### DIFF
--- a/internal/provider/resource_service_connector.go
+++ b/internal/provider/resource_service_connector.go
@@ -216,8 +216,6 @@ func resourceServiceConnectorRead(ctx context.Context, d *schema.ResourceData, m
 		} else {
 			d.Set("resource_type", "")
 		}
-
-		d.Set("user", connector.Body.User.Name)
 	}
 
 	if connector.Metadata != nil {


### PR DESCRIPTION
The user model is no longer part of the body starting with 0.83.0, yet it was still referenced in the service connector logic as if it was mandatory.