### PR TITLE
Add service connector validate flag

### DIFF
--- a/docs/resources/service_connector.md
+++ b/docs/resources/service_connector.md
@@ -29,14 +29,14 @@ resource "zenml_service_connector" "gcp_connector" {
       "auth_uri": "https://accounts.google.com/o/oauth2/auth",
       "token_uri": "https://oauth2.googleapis.com/token"
     })
-
-    verify = true
   }
   
   labels = {
     environment = "production"
     team        = "ml-ops"
   }
+
+  verify = true
 }
 ```
 

--- a/docs/resources/service_connector.md
+++ b/docs/resources/service_connector.md
@@ -29,6 +29,8 @@ resource "zenml_service_connector" "gcp_connector" {
       "auth_uri": "https://accounts.google.com/o/oauth2/auth",
       "token_uri": "https://oauth2.googleapis.com/token"
     })
+
+    verify = true
   }
   
   labels = {
@@ -50,6 +52,7 @@ resource "zenml_service_connector" "gcp_connector" {
 * `resource_type` - (Optional) A resource type this connector can be used for (e.g., `s3-bucket`, `kubernetes-cluster`, `docker-registry`). To find out which resource types are supported by a connector, run `zenml service-connector describe-type <connector-type>`.
 * `configuration` - (Required, Sensitive) A map of configuration key-value pairs for the connector. Every authentication method has its own set of required and optional configuration parameters. To find out which parameters are required and optional for a given authentication method, run `zenml service-connector describe-type <connector-type> -a <auth-method>` or visit the [Service Connector ZenML documentation page](https://docs.zenml.io/how-to/infrastructure-deployment/auth-management) for the connector type and authentication method for more information.
 * `labels` - (Optional) A map of labels to associate with the connector.
+* `verify` - (Optional) Whether to verify the connector configuration and credentials before creating or updating the connector. Defaults to `true`.
 
 ## Attributes Reference
 
@@ -61,6 +64,6 @@ In addition to all arguments above, the following attributes are exported:
 
 Service connectors can be imported using the `id`, e.g.
 
-```
+```shell
 $ terraform import zenml_service_connector.example 12345678-1234-1234-1234-123456789012
 ```

--- a/internal/provider/resource_service_connector.go
+++ b/internal/provider/resource_service_connector.go
@@ -66,6 +66,11 @@ func resourceServiceConnector() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
+			"verify": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
 		},
 
 		CustomizeDiff: func(ctx context.Context, d *schema.ResourceDiff, m interface{}) error {
@@ -143,13 +148,15 @@ func resourceServiceConnectorCreate(ctx context.Context, d *schema.ResourceData,
 	}
 
 	err = retry.RetryContext(ctx, d.Timeout(schema.TimeoutCreate)-time.Minute, func() *retry.RetryError {
-		verify, err := client.VerifyServiceConnector(ctx, *connector)
-		if err != nil {
-			return retry.NonRetryableError(fmt.Errorf("Error verifying service connector: %s", err))
-		}
+		if d.Get("verify").(bool) {
+			verify, err := client.VerifyServiceConnector(ctx, *connector)
+			if err != nil {
+				return retry.NonRetryableError(fmt.Errorf("Error verifying service connector: %s", err))
+			}
 
-		if verify.Error != nil {
-			return retry.RetryableError(fmt.Errorf("error verifying service connector: %s", *verify.Error))
+			if verify.Error != nil {
+				return retry.RetryableError(fmt.Errorf("error verifying service connector: %s", *verify.Error))
+			}
 		}
 
 		resp, err := client.CreateServiceConnector(ctx, *connector)
@@ -236,13 +243,15 @@ func resourceServiceConnectorUpdate(ctx context.Context, d *schema.ResourceData,
 	}
 
 	err = retry.RetryContext(ctx, d.Timeout(schema.TimeoutCreate)-time.Minute, func() *retry.RetryError {
-		resources, err := client.VerifyServiceConnector(ctx, *connector)
-		if err != nil {
-			return retry.NonRetryableError(fmt.Errorf("Error verifying service connector: %s", err))
-		}
+		if d.Get("verify").(bool) {
+			resources, err := client.VerifyServiceConnector(ctx, *connector)
+			if err != nil {
+				return retry.NonRetryableError(fmt.Errorf("Error verifying service connector: %s", err))
+			}
 
-		if resources.Error != nil {
-			return retry.RetryableError(fmt.Errorf("error verifying service connector: %s", *resources.Error))
+			if resources.Error != nil {
+				return retry.RetryableError(fmt.Errorf("error verifying service connector: %s", *resources.Error))
+			}
 		}
 
 		update := ServiceConnectorUpdate{}


### PR DESCRIPTION
Fixes: https://github.com/zenml-io/zenml/issues/3810

Add a flag to control whether the service connector configuration is validated through the server before create and update.