### PR TITLE
Add retry logic for transient HTTP errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ go.work.sum
 #Example
 *.tfstate
 *.tfvars
+
+# ZenML specific
+design/
+.claude/

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 *.dll
 *.so
 *.dylib
+terraform-provider-zenml
+dist/
 
 # Test binary, built with `go test -c`
 *.test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,39 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- `main.go` is the provider entrypoint.
+- `internal/provider/` contains provider logic, resources, data sources, shared models, and tests.
+- `docs/resources/` and `docs/data-sources/` contain provider documentation.
+- `examples/` contains runnable Terraform examples by scenario (`complete-aws`, `complete-gcp`, `project_creation`, etc.).
+- `assets/` stores documentation assets (for example, `assets/workspace_url.png`).
+- `tools/tools.go` pins tool dependencies such as `tfplugindocs`.
+
+## Build, Test, and Development Commands
+- `make build`: Build the provider binary (`terraform-provider-zenml`).
+- `make test`: Run Go tests (`go test ./... -v`).
+- `make testacc`: Run acceptance tests with `TF_ACC=1` and extended timeout.
+- `make docs`: Regenerate docs via `go generate ./...`.
+- `make install VERSION=0.1.0`: Build and install the provider into the local Terraform plugin path.
+- Example targeted run: `go test ./internal/provider -run TestAccStack_basic -v`.
+
+## Coding Style & Naming Conventions
+- Follow standard Go formatting (`gofmt`) and idiomatic import grouping.
+- Keep implementation in package `provider`; prefer focused files per resource/data source.
+- Use existing filename patterns: `resource_<name>.go`, `data_source_<name>.go`, and `*_test.go`.
+- Use acceptance test naming patterns like `TestAcc<Subject>_<Case>` and helper config functions (`testAcc...Config`).
+
+## Testing Guidelines
+- Tests use Go `testing` and `terraform-plugin-testing/helper/resource`.
+- Acceptance tests require `ZENML_SERVER_URL` and one auth variable: `ZENML_API_KEY` or `ZENML_API_TOKEN`.
+- Add/update acceptance tests for provider behavior changes, including import-state checks where applicable.
+- Run `make test` before every PR; run `make testacc` when changing resource or data source behavior.
+
+## Commit & Pull Request Guidelines
+- Prefer short, imperative commit subjects consistent with repo history (for example: `Add ...`, `Fix ...`, optional `(#NN)`).
+- Branch from `main` with descriptive names like `feature/<topic>` or `fix/<topic>`.
+- PRs should include: what changed, why, test evidence, and docs/example updates for user-facing changes.
+
+## Security & Configuration Tips
+- Never commit real credentials or tenant-specific URLs.
+- Use environment variables for auth (`ZENML_SERVER_URL`, `ZENML_API_KEY`, `ZENML_API_TOKEN`).
+- Keep secrets in Terraform `secrets` blocks or external secret managers, not plaintext files.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,72 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build & Development Commands
+
+```bash
+make build          # Build provider binary (terraform-provider-zenml)
+make test           # Run unit tests (go test ./... -v)
+make testacc        # Run acceptance tests (TF_ACC=1, requires running ZenML server, 120m timeout)
+make install        # Build and install to local Terraform plugin directory (~/.terraform.d/plugins/...)
+make docs           # Regenerate provider documentation (go generate ./...)
+make clean          # Remove build artifacts
+```
+
+Run a single test:
+```bash
+go test ./internal/provider -run TestAccStack_basic -v
+```
+
+Acceptance tests require environment variables:
+```bash
+export ZENML_SERVER_URL="https://your-zenml-server.com"
+export ZENML_API_KEY="your-api-key"    # or ZENML_API_TOKEN
+```
+
+## Architecture
+
+This is a **Terraform Provider** for ZenML, built on the modern **Terraform Plugin Framework** (not the legacy SDKv2). It uses Protocol V6 via `providerserver.Serve()` in `main.go`.
+
+### Core flow
+
+```
+main.go → provider.New(version) → ZenMLProvider
+  ├── Configure() → creates Client (custom HTTP client for ZenML REST API)
+  ├── Resources() → Stack, StackComponent, ServiceConnector, Project
+  └── DataSources() → Server, Stack, StackComponent, ServiceConnector
+```
+
+All code lives in a single Go package: `internal/provider/`.
+
+### Key files and their roles
+
+- **provider.go** — Provider schema, authentication (API key or token), server version check (>= 0.80.0), passes `Client` to resources/data sources via `resp.ResourceData`/`resp.DataSourceData`
+- **client.go** — Custom HTTP client for ZenML API v1. Handles token acquisition (API key → password flow → JWT), automatic token refresh (5-minute buffer before expiry), and all CRUD operations. No external ZenML SDK is used.
+- **models.go** — Request/response structs with JSON tags. Separate types for create requests vs read responses. Response bodies nest `Body` (timestamps) and `Metadata` (labels, configs). Uses `Page[T]` for pagination.
+- **validation.go** — Central source of truth for valid enum values: connector types, auth methods per connector, component types, resource types. Also contains `MergeOrCompareConfiguration()` which reconciles Terraform state with server responses (important: the ZenML server can mutate configurations on create/update).
+- **resource_*.go** — Each implements `resource.Resource` + `resource.ResourceWithImportState` with full CRUD + import
+- **data_source_*.go** — Read-only lookups by ID or name
+
+### Configuration reconciliation
+
+A critical design pattern: the ZenML server may add/modify configuration keys when creating or updating components and connectors. `MergeOrCompareConfiguration()` in `validation.go` handles this by merging server responses on top of Terraform state while preserving user-provided keys, and warning about keys the server doesn't recognize.
+
+### File naming conventions
+
+- `resource_<name>.go` / `data_source_<name>.go` / `*_test.go`
+- Test functions: `TestAcc<Subject>_<Case>` with helper config functions `testAcc...Config`
+
+## Adding a New Resource
+
+1. Add request/response structs to `models.go`
+2. Add CRUD client methods to `client.go`
+3. Create `resource_<name>.go` implementing `resource.Resource` with Schema, Create, Read, Update, Delete
+4. Register in `provider.go` → `Resources()`
+5. Add validation constants to `validation.go` if applicable
+6. Add acceptance tests in `resource_<name>_test.go`
+7. Add examples in `examples/` and run `make docs`
+
+## Releases
+
+Automated via GoReleaser on git tag push (`v*`). Version is injected via ldflags (`-X main.version={{.Version}}`). Cross-compiles for linux/darwin/windows/freebsd across amd64/386/arm/arm64. GPG-signed checksums.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This Terraform provider allows you to manage ZenML resources using Infrastructur
 
 - [Terraform](https://www.terraform.io/downloads.html) >= 1.0
 - [Go](https://golang.org/doc/install) >= 1.20
-- [ZenML Server](https://docs.zenml.io/) >= 0.70.0
+- [ZenML Server](https://docs.zenml.io/) >= 0.80.0
 
 ## Building The Provider
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24.0
 toolchain go1.24.7
 
 require (
+	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-retryablehttp v0.7.7
 	github.com/hashicorp/go-version v1.7.0
 	github.com/hashicorp/terraform-plugin-docs v0.19.4
@@ -33,7 +34,6 @@ require (
 	github.com/fatih/color v1.16.0 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/hashicorp/cli v1.1.7 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-checkpoint v0.5.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -5,12 +5,15 @@ go 1.24.0
 toolchain go1.24.7
 
 require (
+	github.com/hashicorp/go-retryablehttp v0.7.7
 	github.com/hashicorp/go-version v1.7.0
 	github.com/hashicorp/terraform-plugin-docs v0.19.4
 	github.com/hashicorp/terraform-plugin-framework v1.16.1
+	github.com/hashicorp/terraform-plugin-framework-timeouts v0.4.1
 	github.com/hashicorp/terraform-plugin-framework-validators v0.12.0
 	github.com/hashicorp/terraform-plugin-go v0.29.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
+	github.com/hashicorp/terraform-plugin-sdk/v2 v2.37.0
 	github.com/hashicorp/terraform-plugin-testing v1.13.3
 )
 
@@ -39,15 +42,12 @@ require (
 	github.com/hashicorp/go-hclog v1.6.3 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-plugin v1.7.0 // indirect
-	github.com/hashicorp/go-retryablehttp v0.7.7 // indirect
 	github.com/hashicorp/go-uuid v1.0.3 // indirect
 	github.com/hashicorp/hc-install v0.9.2 // indirect
 	github.com/hashicorp/hcl/v2 v2.23.0 // indirect
 	github.com/hashicorp/logutils v1.0.0 // indirect
 	github.com/hashicorp/terraform-exec v0.23.1 // indirect
 	github.com/hashicorp/terraform-json v0.27.1 // indirect
-	github.com/hashicorp/terraform-plugin-framework-timeouts v0.4.1 // indirect
-	github.com/hashicorp/terraform-plugin-sdk/v2 v2.37.0 // indirect
 	github.com/hashicorp/terraform-registry-address v0.4.0 // indirect
 	github.com/hashicorp/terraform-svchost v0.1.1 // indirect
 	github.com/hashicorp/yamux v0.1.2 // indirect

--- a/internal/provider/client.go
+++ b/internal/provider/client.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -159,6 +160,15 @@ func (c *Client) doRequest(ctx context.Context, method, path string, body interf
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", accessToken))
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
+	}
+
+	// Set an idempotency key for POST requests so that transport-level retries
+	// (from retryablehttp) are deduplicated by the ZenML server. Each doRequest
+	// call gets a fresh UUID, but retries of the same call reuse the same
+	// http.Request (and thus the same header), which is exactly what the server's
+	// request deduplication expects.
+	if method == "POST" {
+		req.Header.Set("Idempotency-Key", uuid.NewString())
 	}
 
 	tflog.Info(ctx, fmt.Sprintf("[ZENML] Making request: %s %s", method, req.URL.String()))

--- a/internal/provider/client.go
+++ b/internal/provider/client.go
@@ -102,6 +102,11 @@ or use the ZENML_API_KEY environment variable to set the API key.
 	}
 	defer loginResp.Body.Close()
 
+	if loginResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(loginResp.Body)
+		return "", fmt.Errorf("authentication failed: login request returned status %d: %s", loginResp.StatusCode, string(body))
+	}
+
 	var tokenResp struct {
 		AccessToken string `json:"access_token"`
 		ExpiresIn   int    `json:"expires_in"`

--- a/internal/provider/client.go
+++ b/internal/provider/client.go
@@ -36,12 +36,15 @@ func NewClient(serverURL, apiKey string, apiToken string) *Client {
 	retryClient.RetryMax = 4
 	retryClient.Logger = nil
 
+	httpClient := retryClient.StandardClient()
+	httpClient.Timeout = 60 * time.Second
+
 	return &Client{
 		ServerURL:       strings.TrimRight(serverURL, "/"),
 		APIKey:          apiKey,
 		APIToken:        apiToken,
 		APITokenExpires: nil,
-		HTTPClient:      retryClient.StandardClient(),
+		HTTPClient:      httpClient,
 	}
 }
 
@@ -116,10 +119,15 @@ or use the ZENML_API_KEY environment variable to set the API key.
 	}
 
 	c.APIToken = tokenResp.AccessToken
-	// Set the expiry time to 5 minutes before the actual expiry, to account for
-	// clock skew and to avoid using an expired token when making requests
+	// Set the expiry time with a buffer before the actual expiry, to account for
+	// clock skew and to avoid using an expired token when making requests.
+	// Clamp the buffer so short-lived tokens don't get a negative expiry.
+	buffer := 300
+	if tokenResp.ExpiresIn < buffer {
+		buffer = tokenResp.ExpiresIn / 2
+	}
 	expiresAt := time.Now().Add(
-		time.Duration(tokenResp.ExpiresIn-300) * time.Second,
+		time.Duration(tokenResp.ExpiresIn-buffer) * time.Second,
 	)
 	c.APITokenExpires = &expiresAt
 

--- a/internal/provider/client.go
+++ b/internal/provider/client.go
@@ -23,6 +23,19 @@ type ListParams struct {
 	Filter   map[string]string
 }
 
+func normalizeListParams(params *ListParams) *ListParams {
+	if params == nil {
+		return &ListParams{Page: 1, PageSize: 100}
+	}
+	if params.Page <= 0 {
+		params.Page = 1
+	}
+	if params.PageSize <= 0 {
+		params.PageSize = 100
+	}
+	return params
+}
+
 type Client struct {
 	ServerURL       string
 	APIKey          string
@@ -50,6 +63,15 @@ func NewClient(serverURL, apiKey string, apiToken string) *Client {
 		APITokenExpires: nil,
 		HTTPClient:      httpClient,
 	}
+}
+
+// invalidateToken atomically clears the cached token so the next call to
+// getAPIToken will re-authenticate using the API key.
+func (c *Client) invalidateToken() {
+	c.tokenMu.Lock()
+	defer c.tokenMu.Unlock()
+	c.APIToken = ""
+	c.APITokenExpires = nil
 }
 
 func (c *Client) getAPIToken(ctx context.Context) (string, error) {
@@ -168,12 +190,17 @@ func (c *Client) doRequest(ctx context.Context, method, path string, body interf
 
 	url := fmt.Sprintf("%s%s", c.ServerURL, path)
 	tflog.Info(ctx, fmt.Sprintf("[ZENML] Making request: %s %s", method, url))
-	if body != nil {
-		prettyJSON, _ := json.MarshalIndent(body, "", "  ")
-		tflog.Debug(ctx, fmt.Sprintf("[ZENML] Request body (JSON):\n%s", prettyJSON))
+	if jsonBody != nil {
+		var indented bytes.Buffer
+		if json.Indent(&indented, jsonBody, "", "  ") == nil {
+			tflog.Debug(ctx, fmt.Sprintf("[ZENML] Request body (JSON):\n%s", indented.String()))
+		}
 	}
 
 	// Allow one retry on 401 when an API key is available for re-authentication.
+	// Note: retryablehttp handles transport-level retries (connection errors, 5xx,
+	// 429) transparently. This loop only retries on 401 (auth expiry), which
+	// retryablehttp does not retry. The two layers are complementary, not multiplicative.
 	maxAttempts := 1
 	if c.APIKey != "" {
 		maxAttempts = 2
@@ -229,10 +256,7 @@ func (c *Client) doRequest(ctx context.Context, method, path string, body interf
 		// On 401, invalidate the cached token and retry with fresh credentials.
 		if resp.StatusCode == http.StatusUnauthorized && attempt < maxAttempts-1 {
 			tflog.Info(ctx, "[ZENML] Got 401, refreshing token and retrying")
-			c.tokenMu.Lock()
-			c.APIToken = ""
-			c.APITokenExpires = nil
-			c.tokenMu.Unlock()
+			c.invalidateToken()
 			continue
 		}
 
@@ -326,20 +350,7 @@ func (c *Client) DeleteStack(ctx context.Context, id string) error {
 }
 
 func (c *Client) ListStacks(ctx context.Context, params *ListParams) (*Page[StackResponse], error) {
-	if params == nil {
-		params = &ListParams{
-			Page:     1,
-			PageSize: 100,
-		}
-	} else {
-		if params.Page <= 0 {
-			params.Page = 1
-		}
-		if params.PageSize <= 0 {
-			params.PageSize = 100
-		}
-	}
-
+	params = normalizeListParams(params)
 	query := url.Values{}
 	query.Add("page", fmt.Sprintf("%d", params.Page))
 	query.Add("size", fmt.Sprintf("%d", params.PageSize))
@@ -425,20 +436,7 @@ func (c *Client) DeleteComponent(ctx context.Context, id string) error {
 }
 
 func (c *Client) ListStackComponents(ctx context.Context, params *ListParams) (*Page[ComponentResponse], error) {
-	if params == nil {
-		params = &ListParams{
-			Page:     1,
-			PageSize: 100,
-		}
-	} else {
-		if params.Page <= 0 {
-			params.Page = 1
-		}
-		if params.PageSize <= 0 {
-			params.PageSize = 100
-		}
-	}
-
+	params = normalizeListParams(params)
 	query := url.Values{}
 	query.Add("page", fmt.Sprintf("%d", params.Page))
 	query.Add("size", fmt.Sprintf("%d", params.PageSize))
@@ -538,20 +536,7 @@ func (c *Client) DeleteServiceConnector(ctx context.Context, id string) error {
 }
 
 func (c *Client) ListServiceConnectors(ctx context.Context, params *ListParams) (*Page[ServiceConnectorResponse], error) {
-	if params == nil {
-		params = &ListParams{
-			Page:     1,
-			PageSize: 100,
-		}
-	} else {
-		if params.Page <= 0 {
-			params.Page = 1
-		}
-		if params.PageSize <= 0 {
-			params.PageSize = 100
-		}
-	}
-
+	params = normalizeListParams(params)
 	query := url.Values{}
 	query.Add("page", fmt.Sprintf("%d", params.Page))
 	query.Add("size", fmt.Sprintf("%d", params.PageSize))

--- a/internal/provider/client.go
+++ b/internal/provider/client.go
@@ -38,7 +38,10 @@ func NewClient(serverURL, apiKey string, apiToken string) *Client {
 	retryClient.Logger = nil
 
 	httpClient := retryClient.StandardClient()
-	httpClient.Timeout = 60 * time.Second
+	// No hard client timeout — context deadlines from Terraform resource
+	// timeouts handle cancellation. A fixed timeout here would conflict
+	// with retryablehttp backoff and risk killing long-running operations
+	// (e.g. service connector verification) prematurely.
 
 	return &Client{
 		ServerURL:       strings.TrimRight(serverURL, "/"),
@@ -120,96 +123,130 @@ or use the ZENML_API_KEY environment variable to set the API key.
 	}
 
 	c.APIToken = tokenResp.AccessToken
-	// Set the expiry time with a buffer before the actual expiry, to account for
-	// clock skew and to avoid using an expired token when making requests.
-	// Clamp the buffer so short-lived tokens don't get a negative expiry.
-	buffer := 300
-	if tokenResp.ExpiresIn < buffer {
-		buffer = tokenResp.ExpiresIn / 2
+	if tokenResp.ExpiresIn <= 0 {
+		// Server returned no expiry or an invalid value — treat the token
+		// as non-expiring so we don't force a refresh on every request.
+		c.APITokenExpires = nil
+	} else {
+		// Set the expiry time with a buffer before the actual expiry, to account
+		// for clock skew and to avoid using an expired token when making requests.
+		// Clamp the buffer so short-lived tokens don't get a negative expiry.
+		buffer := 300
+		if tokenResp.ExpiresIn < buffer {
+			buffer = tokenResp.ExpiresIn / 2
+		}
+		expiresAt := time.Now().Add(
+			time.Duration(tokenResp.ExpiresIn-buffer) * time.Second,
+		)
+		c.APITokenExpires = &expiresAt
 	}
-	expiresAt := time.Now().Add(
-		time.Duration(tokenResp.ExpiresIn-buffer) * time.Second,
-	)
-	c.APITokenExpires = &expiresAt
 
 	return c.APIToken, nil
 }
 
 func (c *Client) doRequest(ctx context.Context, method, path string, body interface{}) (*http.Response, int, error) {
-	var bodyReader io.Reader
-
+	// Marshal body once — reused if we need to retry on 401.
+	var jsonBody []byte
 	if body != nil {
-		jsonBody, err := json.Marshal(body)
+		var err error
+		jsonBody, err = json.Marshal(body)
 		if err != nil {
 			return nil, 0, fmt.Errorf("error marshaling request body: %v", err)
 		}
-		bodyReader = bytes.NewBuffer(jsonBody)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, method, fmt.Sprintf("%s%s", c.ServerURL, path), bodyReader)
-	if err != nil {
-		return nil, 0, fmt.Errorf("error creating request: %v", err)
-	}
-
-	accessToken, err := c.getAPIToken(ctx)
-
-	if err != nil {
-		return nil, 0, fmt.Errorf("error getting API token: %v", err)
-	}
-
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", accessToken))
-	if body != nil {
-		req.Header.Set("Content-Type", "application/json")
-	}
-
-	// Set an idempotency key for POST requests so that transport-level retries
-	// (from retryablehttp) are deduplicated by the ZenML server. Each doRequest
-	// call gets a fresh UUID, but retries of the same call reuse the same
-	// http.Request (and thus the same header), which is exactly what the server's
-	// request deduplication expects.
+	// Generate idempotency key once for POST requests — reused across retries
+	// so the server deduplicates transport-level and auth-refresh retries alike.
+	//
+	// NOTE: This relies on the ZenML server having request_deduplication enabled
+	// (the default). If a server admin disables it, retried POST requests could
+	// create duplicate resources. See the ZenML RequestManager for details.
+	var idempotencyKey string
 	if method == "POST" {
-		req.Header.Set("Idempotency-Key", uuid.NewString())
+		idempotencyKey = uuid.NewString()
 	}
 
-	tflog.Info(ctx, fmt.Sprintf("[ZENML] Making request: %s %s", method, req.URL.String()))
+	url := fmt.Sprintf("%s%s", c.ServerURL, path)
+	tflog.Info(ctx, fmt.Sprintf("[ZENML] Making request: %s %s", method, url))
 	if body != nil {
 		prettyJSON, _ := json.MarshalIndent(body, "", "  ")
 		tflog.Debug(ctx, fmt.Sprintf("[ZENML] Request body (JSON):\n%s", prettyJSON))
 	}
 
-	resp, err := c.HTTPClient.Do(req)
-	if err != nil {
-		return nil, 0, fmt.Errorf("error making request: %v", err)
+	// Allow one retry on 401 when an API key is available for re-authentication.
+	maxAttempts := 1
+	if c.APIKey != "" {
+		maxAttempts = 2
 	}
 
-	// Read the response body once and store it in a variable
-	defer resp.Body.Close()
-	resp_body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, 0, fmt.Errorf("error reading response body: %v", err)
-	}
-
-	// Print the response body as JSON if available
-	if len(resp_body) > 0 {
-		var prettyBody map[string]interface{}
-		if err := json.Unmarshal(resp_body, &prettyBody); err == nil {
-			prettyJSON, _ := json.MarshalIndent(prettyBody, "", "  ")
-			tflog.Debug(ctx, fmt.Sprintf("[ZENML] Response body (JSON):\n%s", prettyJSON))
-		} else {
-			tflog.Debug(ctx, fmt.Sprintf("[ZENML] Response body:\n%s", string(resp_body)))
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		var bodyReader io.Reader
+		if jsonBody != nil {
+			bodyReader = bytes.NewReader(jsonBody)
 		}
+
+		req, err := http.NewRequestWithContext(ctx, method, url, bodyReader)
+		if err != nil {
+			return nil, 0, fmt.Errorf("error creating request: %v", err)
+		}
+
+		accessToken, err := c.getAPIToken(ctx)
+		if err != nil {
+			return nil, 0, fmt.Errorf("error getting API token: %v", err)
+		}
+
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", accessToken))
+		if jsonBody != nil {
+			req.Header.Set("Content-Type", "application/json")
+		}
+		if idempotencyKey != "" {
+			req.Header.Set("Idempotency-Key", idempotencyKey)
+		}
+
+		resp, err := c.HTTPClient.Do(req)
+		if err != nil {
+			return nil, 0, fmt.Errorf("error making request: %v", err)
+		}
+
+		respBody, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			return nil, 0, fmt.Errorf("error reading response body: %v", err)
+		}
+
+		if len(respBody) > 0 {
+			var prettyBody map[string]interface{}
+			if err := json.Unmarshal(respBody, &prettyBody); err == nil {
+				prettyJSON, _ := json.MarshalIndent(prettyBody, "", "  ")
+				tflog.Debug(ctx, fmt.Sprintf("[ZENML] Response body (JSON):\n%s", prettyJSON))
+			} else {
+				tflog.Debug(ctx, fmt.Sprintf("[ZENML] Response body:\n%s", string(respBody)))
+			}
+		}
+
+		tflog.Info(ctx, fmt.Sprintf("[ZENML] Response status: %d", resp.StatusCode))
+
+		// On 401, invalidate the cached token and retry with fresh credentials.
+		if resp.StatusCode == http.StatusUnauthorized && attempt < maxAttempts-1 {
+			tflog.Info(ctx, "[ZENML] Got 401, refreshing token and retrying")
+			c.tokenMu.Lock()
+			c.APIToken = ""
+			c.APITokenExpires = nil
+			c.tokenMu.Unlock()
+			continue
+		}
+
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			return nil, resp.StatusCode, fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(respBody))
+		}
+
+		// Re-wrap the body so that the caller can still read it
+		resp.Body = io.NopCloser(bytes.NewReader(respBody))
+		return resp, resp.StatusCode, nil
 	}
 
-	tflog.Info(ctx, fmt.Sprintf("[ZENML] Response status: %d", resp.StatusCode))
-
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, resp.StatusCode, fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(resp_body))
-	}
-
-	// Re-wrap the body so that the caller can still read it
-	resp.Body = io.NopCloser(bytes.NewReader(resp_body))
-
-	return resp, resp.StatusCode, nil
+	// Unreachable in practice, but satisfies the compiler.
+	return nil, 0, fmt.Errorf("exhausted request attempts")
 }
 
 // GetServerInfo fetches server info to determine version and capabilities

--- a/internal/provider/client.go
+++ b/internal/provider/client.go
@@ -8,8 +8,11 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
+	"sync"
 	"time"
 
+	"github.com/hashicorp/go-retryablehttp"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
@@ -25,19 +28,27 @@ type Client struct {
 	APIToken        string
 	APITokenExpires *time.Time
 	HTTPClient      *http.Client
+	tokenMu         sync.Mutex
 }
 
 func NewClient(serverURL, apiKey string, apiToken string) *Client {
+	retryClient := retryablehttp.NewClient()
+	retryClient.RetryMax = 4
+	retryClient.Logger = nil
+
 	return &Client{
-		ServerURL:       serverURL,
+		ServerURL:       strings.TrimRight(serverURL, "/"),
 		APIKey:          apiKey,
 		APIToken:        apiToken,
 		APITokenExpires: nil,
-		HTTPClient:      &http.Client{},
+		HTTPClient:      retryClient.StandardClient(),
 	}
 }
 
 func (c *Client) getAPIToken(ctx context.Context) (string, error) {
+	c.tokenMu.Lock()
+	defer c.tokenMu.Unlock()
+
 	if c.APIToken != "" {
 		if c.APITokenExpires == nil {
 			// No expiry, so just return the token
@@ -75,7 +86,8 @@ or use the ZENML_API_KEY environment variable to set the API key.
 	// Get a new token from the API key using the password flow
 	data := url.Values{}
 	data.Set("password", c.APIKey)
-	loginReq, err := http.NewRequest(
+	loginReq, err := http.NewRequestWithContext(
+		ctx,
 		"POST",
 		fmt.Sprintf("%s/api/v1/login", c.ServerURL),
 		bytes.NewBufferString(data.Encode()),
@@ -120,7 +132,7 @@ func (c *Client) doRequest(ctx context.Context, method, path string, body interf
 		bodyReader = bytes.NewBuffer(jsonBody)
 	}
 
-	req, err := http.NewRequest(method, fmt.Sprintf("%s%s", c.ServerURL, path), bodyReader)
+	req, err := http.NewRequestWithContext(ctx, method, fmt.Sprintf("%s%s", c.ServerURL, path), bodyReader)
 	if err != nil {
 		return nil, 0, fmt.Errorf("error creating request: %v", err)
 	}
@@ -149,7 +161,10 @@ func (c *Client) doRequest(ctx context.Context, method, path string, body interf
 
 	// Read the response body once and store it in a variable
 	defer resp.Body.Close()
-	resp_body, _ := io.ReadAll(resp.Body)
+	resp_body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, 0, fmt.Errorf("error reading response body: %v", err)
+	}
 
 	// Print the response body as JSON if available
 	if len(resp_body) > 0 {

--- a/internal/provider/resource_service_connector.go
+++ b/internal/provider/resource_service_connector.go
@@ -445,7 +445,7 @@ func (r *ServiceConnectorResource) Create(ctx context.Context, req resource.Crea
 		retryErr := retry.RetryContext(ctx, createTimeout, func() *retry.RetryError {
 			validation, err := r.client.VerifyServiceConnector(ctx, *connectorReq)
 			if err != nil {
-				return retry.RetryableError(fmt.Errorf("unable to verify service connector configuration, got error: %s", err))
+				return retry.NonRetryableError(fmt.Errorf("unable to verify service connector configuration, got error: %s", err))
 			}
 			if validation.Error != nil {
 				return retry.RetryableError(fmt.Errorf("Error verifying service connector configuration: %s", *validation.Error))
@@ -536,7 +536,7 @@ func (r *ServiceConnectorResource) Update(ctx context.Context, req resource.Upda
 		retryErr := retry.RetryContext(ctx, updateTimeout, func() *retry.RetryError {
 			validation, err := r.client.VerifyServiceConnector(ctx, *connectorReq)
 			if err != nil {
-				return retry.RetryableError(fmt.Errorf("unable to verify service connector configuration, got error: %s", err))
+				return retry.NonRetryableError(fmt.Errorf("unable to verify service connector configuration, got error: %s", err))
 			}
 			if validation.Error != nil {
 				return retry.RetryableError(fmt.Errorf("Error verifying service connector configuration: %s", *validation.Error))

--- a/internal/provider/resource_service_connector.go
+++ b/internal/provider/resource_service_connector.go
@@ -445,7 +445,7 @@ func (r *ServiceConnectorResource) Create(ctx context.Context, req resource.Crea
 		retryErr := retry.RetryContext(ctx, createTimeout, func() *retry.RetryError {
 			validation, err := r.client.VerifyServiceConnector(ctx, *connectorReq)
 			if err != nil {
-				return retry.NonRetryableError(fmt.Errorf("unable to verify service connector configuration, got error: %s", err))
+				return retry.RetryableError(fmt.Errorf("unable to verify service connector configuration, got error: %s", err))
 			}
 			if validation.Error != nil {
 				return retry.RetryableError(fmt.Errorf("Error verifying service connector configuration: %s", *validation.Error))
@@ -536,7 +536,7 @@ func (r *ServiceConnectorResource) Update(ctx context.Context, req resource.Upda
 		retryErr := retry.RetryContext(ctx, updateTimeout, func() *retry.RetryError {
 			validation, err := r.client.VerifyServiceConnector(ctx, *connectorReq)
 			if err != nil {
-				return retry.NonRetryableError(fmt.Errorf("unable to verify service connector configuration, got error: %s", err))
+				return retry.RetryableError(fmt.Errorf("unable to verify service connector configuration, got error: %s", err))
 			}
 			if validation.Error != nil {
 				return retry.RetryableError(fmt.Errorf("Error verifying service connector configuration: %s", *validation.Error))


### PR DESCRIPTION
## Summary

- Adds automatic retry with exponential backoff for transient HTTP errors (connection reset by peer, EOF, timeouts, 429, 5xx) using HashiCorp go-retryablehttp
- Adds Idempotency-Key header on POST requests so transport-level retries are deduplicated by the ZenML server (mirrors the Python client approach)
- Adds retry-once-on-401 flow: if a request gets 401, invalidates cached token, re-acquires via API key, retries with same Idempotency-Key
- Fixes missing context propagation on HTTP requests (enables Terraform cancellation to stop in-flight requests)
- Adds mutex for thread-safe API token refresh (prevents races when Terraform reads resources in parallel)
- Fixes silently discarded io.ReadAll errors that could mask transient failures
- Adds login response status code checking (previously a non-200 login response would produce misleading JSON decode errors)
- Clamps token refresh buffer so short-lived tokens (ExpiresIn < 300s) dont trigger re-auth on every request
- Guards against expires_in <= 0 from server (treats token as non-expiring instead of forcing refresh every request)
- Removes hard 60s HTTP timeout that conflicted with retryablehttp backoff; relies on Terraform context deadlines instead
- Aligns README version requirement with provider.go enforcement (>= 0.80.0)
- Adds CLAUDE.md and AGENTS.md for agentic coding guidance
- Adds gitignore rules for provider binary and dist/

## Code quality improvements (latest commit)

- Extracted `invalidateToken()` method for atomic token clearing on 401 (was inline lock/clear/unlock)
- Extracted `normalizeListParams()` helper to deduplicate 3 identical param-validation blocks across List functions
- Fixed double JSON marshaling in debug logging: reuses already-marshaled `jsonBody` bytes via `json.Indent` instead of re-marshaling the original struct
- Added comment documenting that retryablehttp (transport retries) and the 401 loop (auth retries) are complementary, not multiplicative

## Context

A community user reported intermittent connection reset by peer errors when deploying ZenML infrastructure via Terraform. The root cause: the provider HTTP client (client.go:doRequest) made exactly one attempt per request with no retry logic. Any transient TCP disruption (load balancer timeout, brief network blip, server restart) would immediately fail the entire Terraform operation.

## What changed

| File | Change |
|------|--------|
| internal/provider/client.go | retryablehttp with 4 retries and exponential backoff. No hard client timeout (relies on ctx deadlines). Token mutex, context-aware requests, login status checking, expiry buffer clamp, expires_in guard. POST Idempotency-Key header. 401 re-auth retry. Code cleanup: invalidateToken(), normalizeListParams(), fix double-marshal. |
| go.mod | go-retryablehttp and google/uuid promoted to direct deps |
| README.md | Version requirement updated to >= 0.80.0 |
| .gitignore | Added terraform-provider-zenml, dist/, editor files |
| CLAUDE.md | New: Claude Code project instructions |
| AGENTS.md | New: Agentic coding guidance |

## POST retry safety

go-retryablehttp retries all HTTP methods by default including POST. Without protection, a retried POST that actually succeeded server-side would hit uniqueness constraints (409 Conflict), causing Terraform to fail the create while the resource exists in ZenML.

The fix mirrors the ZenML Python client approach: each POST request includes an Idempotency-Key UUID header. The ZenML server request deduplication (enabled by default) caches the original response keyed by this UUID, so retries receive the cached success response instead of re-executing the create.

Note: POST retry safety relies on ZenML server request_deduplication being enabled (the default). If disabled server-side, retried POSTs could create duplicates.

## 401 re-authentication

When doRequest receives a 401 Unauthorized response and an API key is configured, it now:
1. Invalidates the cached token (clears APIToken and APITokenExpires)
2. Re-acquires a fresh token via the API key login flow
3. Retries the request once with the new token and the same Idempotency-Key

This handles cases where tokens are revoked server-side before the client expiry buffer fires (e.g. server restart, manual revocation, key rotation).

## Test plan

- [x] go build passes
- [x] go test passes (unit tests)
- [ ] Needs manual e2e testing - acceptance tests (make testacc) should be run against a live ZenML server to verify the retry behavior does not introduce regressions