### PR TITLE
update `zenml_stack` in place instead of replacing on components diffs

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,8 @@ resource "zenml_stack" "ml_stack" {
 }
 ```
 
+`zenml_stack` updates are applied in place (including component map changes) to preserve the ZenML stack identity and avoid delete/recreate behavior during re-applies. Snapshot rebuilds may still be required when stack changes introduce new runtime dependencies.
+
 See the [examples](./examples/) directory for more complete examples.
 
 ## Development

--- a/docs/resources/stack.md
+++ b/docs/resources/stack.md
@@ -9,6 +9,7 @@ description: |-
 
 Manages a ZenML stack, which is a collection of components that define the infrastructure for your ML pipelines.
 
+
 ## Example Usage
 
 ```hcl
@@ -68,6 +69,10 @@ resource "zenml_stack" "my_stack" {
   * `feature_store`
   * `image_builder`
 * `labels` - (Optional) A map of labels to associate with the stack.
+
+## Update Behavior
+
+Updating stack labels, name, or component references is performed in place whenever supported by the ZenML API. This preserves the stack ID and avoids transient outages caused by deleting and recreating the stack during `terraform apply`.
 
 ## Attributes Reference
 

--- a/internal/provider/client.go
+++ b/internal/provider/client.go
@@ -288,6 +288,67 @@ func (c *Client) ListStacks(ctx context.Context, params *ListParams) (*Page[Stac
 	return &result, nil
 }
 
+// ListStacksByComponent returns all stacks that use the given component.
+func (c *Client) ListStacksByComponent(
+	ctx context.Context,
+	componentID string,
+) ([]StackResponse, error) {
+	params := &ListParams{
+		Filter: map[string]string{
+			"component_id": componentID,
+		},
+	}
+	page, err := c.ListStacks(ctx, params)
+	if err != nil {
+		return nil, err
+	}
+	return page.Items, nil
+}
+
+// RemoveComponentFromStack removes a specific component by ID from a stack.
+// Since stacks can have multiple components of the same type, this filters
+// out only the component with the matching ID.
+func (c *Client) RemoveComponentFromStack(
+	ctx context.Context,
+	stackID string,
+	componentID string,
+) error {
+	stack, err := c.GetStack(ctx, stackID)
+	if err != nil {
+		return err
+	}
+	if stack == nil {
+		return fmt.Errorf("stack %s not found", stackID)
+	}
+
+	newComponents := make(map[string][]string)
+	for compType, compList := range stack.Metadata.Components {
+		var filteredIDs []string
+		for _, comp := range compList {
+			if comp.ID != componentID {
+				filteredIDs = append(filteredIDs, comp.ID)
+			}
+		}
+		if len(filteredIDs) > 0 {
+			newComponents[compType] = filteredIDs
+		}
+	}
+
+	labels := make(map[string]string)
+	if stack.Metadata != nil && stack.Metadata.Labels != nil {
+		labels = stack.Metadata.Labels
+	}
+
+	update := StackUpdate{
+		Name:       stack.Name,
+		Components: newComponents,
+		Labels:     labels,
+	}
+
+	_, err = c.UpdateStack(ctx, stackID, update)
+	return err
+}
+
 // Component operations...
 func (c *Client) CreateComponent(ctx context.Context, component ComponentRequest) (*ComponentResponse, error) {
 	endpoint := "/api/v1/components"

--- a/internal/provider/resource_stack.go
+++ b/internal/provider/resource_stack.go
@@ -21,6 +21,62 @@ var _ resource.Resource = &StackResource{}
 var _ resource.ResourceWithImportState = &StackResource{}
 var _ resource.ResourceWithConfigValidators = &StackResource{}
 
+// requiresReplaceIfRequiredComponentChanges is a plan modifier that triggers
+// resource replacement when required component types (orchestrator,
+// artifact_store) change. These components cannot be removed from a stack, so
+// changing them requires replacing the entire stack.
+type requiresReplaceIfRequiredComponentChanges struct{}
+
+var _ planmodifier.Map = requiresReplaceIfRequiredComponentChanges{}
+
+func (m requiresReplaceIfRequiredComponentChanges) Description(
+	ctx context.Context,
+) string {
+	return "Requires replacement when orchestrator or artifact_store changes"
+}
+
+func (m requiresReplaceIfRequiredComponentChanges) MarkdownDescription(
+	ctx context.Context,
+) string {
+	return "Requires replacement when orchestrator or artifact_store changes"
+}
+
+func (m requiresReplaceIfRequiredComponentChanges) PlanModifyMap(
+	ctx context.Context,
+	req planmodifier.MapRequest,
+	resp *planmodifier.MapResponse,
+) {
+	if req.StateValue.IsNull() || req.PlanValue.IsNull() || req.PlanValue.IsUnknown() {
+		return
+	}
+
+	var oldComponents, newComponents map[string]types.String
+	resp.Diagnostics.Append(req.StateValue.ElementsAs(ctx, &oldComponents, false)...)
+	resp.Diagnostics.Append(req.PlanValue.ElementsAs(ctx, &newComponents, false)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	for requiredType := range requiredComponentTypes {
+		oldVal := oldComponents[requiredType]
+		newVal := newComponents[requiredType]
+
+		oldID := ""
+		if !oldVal.IsNull() && !oldVal.IsUnknown() {
+			oldID = oldVal.ValueString()
+		}
+		newID := ""
+		if !newVal.IsNull() && !newVal.IsUnknown() {
+			newID = newVal.ValueString()
+		}
+
+		if oldID != newID {
+			resp.RequiresReplace = true
+			return
+		}
+	}
+}
+
 func NewStackResource() resource.Resource {
 	return &StackResource{}
 }
@@ -57,9 +113,14 @@ func (r *StackResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 				Required:            true,
 			},
 			"components": schema.MapAttribute{
-				MarkdownDescription: "Map of component types to component IDs",
-				ElementType:         types.StringType,
-				Required:            true,
+				MarkdownDescription: "Map of component types to component IDs. " +
+					"Changing the orchestrator or artifact_store will force " +
+					"stack replacement since these are required components.",
+				ElementType: types.StringType,
+				Required:    true,
+				PlanModifiers: []planmodifier.Map{
+					requiresReplaceIfRequiredComponentChanges{},
+				},
 			},
 			"labels": schema.MapAttribute{
 				MarkdownDescription: "Labels for the stack",

--- a/internal/provider/resource_stack.go
+++ b/internal/provider/resource_stack.go
@@ -119,11 +119,15 @@ func (v stackConfigValidator) ValidateResource(ctx context.Context, req resource
 				continue
 			}
 
-			if compID.IsNull() || compID.IsUnknown() || strings.TrimSpace(compID.ValueString()) == "" {
+			if compID.IsUnknown() {
+				continue
+			}
+
+			if compID.IsNull() || strings.TrimSpace(compID.ValueString()) == "" {
 				resp.Diagnostics.AddAttributeError(
 					path.Root("components").AtMapKey(compType),
 					"Invalid component ID",
-					"Component IDs in the stack components map must be known, non-null, and non-empty.",
+					"Component IDs in the stack components map must be non-null and non-empty (unknown values from resource references are allowed during planning).",
 				)
 			}
 		}

--- a/internal/provider/resource_stack.go
+++ b/internal/provider/resource_stack.go
@@ -119,15 +119,15 @@ func (v stackConfigValidator) ValidateResource(ctx context.Context, req resource
 				continue
 			}
 
-			if compID.IsUnknown() {
+			if compID.IsUnknown() || compID.IsNull() {
 				continue
 			}
 
-			if compID.IsNull() || strings.TrimSpace(compID.ValueString()) == "" {
+			if strings.TrimSpace(compID.ValueString()) == "" {
 				resp.Diagnostics.AddAttributeError(
 					path.Root("components").AtMapKey(compType),
 					"Invalid component ID",
-					"Component IDs in the stack components map must be non-null and non-empty (unknown values from resource references are allowed during planning).",
+					"Component IDs must be non-empty strings when provided; null and unknown values are allowed during planning.",
 				)
 			}
 		}

--- a/internal/provider/resource_stack.go
+++ b/internal/provider/resource_stack.go
@@ -11,7 +11,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -61,9 +60,6 @@ func (r *StackResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 				MarkdownDescription: "Map of component types to component IDs",
 				ElementType:         types.StringType,
 				Required:            true,
-				PlanModifiers: []planmodifier.Map{
-					mapplanmodifier.RequiresReplace(),
-				},
 			},
 			"labels": schema.MapAttribute{
 				MarkdownDescription: "Labels for the stack",
@@ -106,7 +102,7 @@ func (v stackConfigValidator) ValidateResource(ctx context.Context, req resource
 			return
 		}
 
-		for compType, _ := range componentElements {
+		for compType, compID := range componentElements {
 			valid := false
 			for _, validType := range validComponentTypes {
 				if compType == validType {
@@ -121,6 +117,14 @@ func (v stackConfigValidator) ValidateResource(ctx context.Context, req resource
 					fmt.Sprintf("Invalid component type %q. Valid types are: %s", compType, strings.Join(validComponentTypes, ", ")),
 				)
 				continue
+			}
+
+			if compID.IsNull() || compID.IsUnknown() || strings.TrimSpace(compID.ValueString()) == "" {
+				resp.Diagnostics.AddAttributeError(
+					path.Root("components").AtMapKey(compType),
+					"Invalid component ID",
+					"Component IDs in the stack components map must be known, non-null, and non-empty.",
+				)
 			}
 		}
 	}
@@ -156,67 +160,155 @@ func (r *StackResource) populateStackModel(
 	data.Name = types.StringValue(stack.Name)
 
 	if stack.Metadata != nil {
-		if stack.Metadata.Components != nil {
-			componentMap := make(map[string]attr.Value)
-
-			// First, preserve null components from existing state
-			if !data.Components.IsNull() && !data.Components.IsUnknown() {
-				existingComponents := make(map[string]types.String)
-				diags.Append(
-					data.Components.ElementsAs(
-						ctx,
-						&existingComponents,
-						false,
-					)...,
-				)
-				if diags.HasError() {
-					return
-				}
-
-				// Keep only the null entries
-				for compType, compValue := range existingComponents {
-					if compValue.IsNull() {
-						componentMap[compType] = types.StringNull()
-					}
-				}
-			}
-
-			// Apply components from API response on top of nulls
-			for compType, compList := range stack.Metadata.Components {
-				if len(compList) > 0 {
-					componentMap[compType] = types.StringValue(
-						compList[0].ID,
-					)
-				}
-			}
-
-			componentValue, componentDiags := types.MapValue(
-				types.StringType,
-				componentMap,
-			)
-			diags.Append(componentDiags...)
-			if !diags.HasError() {
-				data.Components = componentValue
-			}
+		componentValue := r.flattenStackComponentsToTFMap(ctx, stack.Metadata.Components, data.Components, diags)
+		if diags.HasError() {
+			return
+		}
+		if componentValue != nil {
+			data.Components = *componentValue
 		}
 
-		if len(stack.Metadata.Labels) > 0 {
-			labelMap := make(map[string]attr.Value)
-			for k, v := range stack.Metadata.Labels {
-				labelMap[k] = types.StringValue(v)
-			}
-			labelValue, labelDiags := types.MapValue(
-				types.StringType,
-				labelMap,
-			)
-			diags.Append(labelDiags...)
-			if !diags.HasError() {
-				data.Labels = labelValue
-			}
-		} else if !data.Labels.IsNull() && len(data.Labels.Elements()) > 0 {
-			data.Labels = types.MapNull(types.StringType)
+		labelValue := flattenStringMapToTFMap(stack.Metadata.Labels, data.Labels, diags)
+		if diags.HasError() {
+			return
+		}
+		if labelValue != nil {
+			data.Labels = *labelValue
 		}
 	}
+}
+
+func expandStackComponentsFromTF(
+	ctx context.Context,
+	components types.Map,
+	diags *diag.Diagnostics,
+) map[string][]string {
+	result := make(map[string][]string)
+	if components.IsNull() || components.IsUnknown() {
+		return result
+	}
+
+	componentElements := make(map[string]types.String, len(components.Elements()))
+	diags.Append(components.ElementsAs(ctx, &componentElements, false)...)
+	if diags.HasError() {
+		return nil
+	}
+
+	for compType, compID := range componentElements {
+		if compID.IsNull() || compID.IsUnknown() {
+			continue
+		}
+
+		id := strings.TrimSpace(compID.ValueString())
+		if id == "" {
+			continue
+		}
+		result[compType] = []string{id}
+	}
+
+	return result
+}
+
+func expandStringMapFromTF(
+	ctx context.Context,
+	values types.Map,
+	diags *diag.Diagnostics,
+) map[string]string {
+	result := make(map[string]string)
+	if values.IsNull() || values.IsUnknown() {
+		return result
+	}
+
+	elements := make(map[string]types.String, len(values.Elements()))
+	diags.Append(values.ElementsAs(ctx, &elements, false)...)
+	if diags.HasError() {
+		return nil
+	}
+
+	for k, v := range elements {
+		if v.IsNull() || v.IsUnknown() {
+			continue
+		}
+		result[k] = v.ValueString()
+	}
+
+	return result
+}
+
+func flattenStringMapToTFMap(
+	values map[string]string,
+	existing types.Map,
+	diags *diag.Diagnostics,
+) *types.Map {
+	if len(values) == 0 {
+		if !existing.IsNull() && len(existing.Elements()) > 0 {
+			nullMap := types.MapNull(types.StringType)
+			return &nullMap
+		}
+		return nil
+	}
+
+	valueMap := make(map[string]attr.Value, len(values))
+	for k, v := range values {
+		valueMap[k] = types.StringValue(v)
+	}
+
+	tfMap, tfDiags := types.MapValue(types.StringType, valueMap)
+	diags.Append(tfDiags...)
+	if diags.HasError() {
+		return nil
+	}
+
+	return &tfMap
+}
+
+func (r *StackResource) flattenStackComponentsToTFMap(
+	ctx context.Context,
+	apiComponents map[string][]ComponentResponse,
+	existing types.Map,
+	diags *diag.Diagnostics,
+) *types.Map {
+	if apiComponents == nil {
+		return nil
+	}
+
+	componentMap := make(map[string]attr.Value)
+
+	// Preserve explicit null placeholders from prior state without inventing new ones.
+	if !existing.IsNull() && !existing.IsUnknown() {
+		existingComponents := make(map[string]types.String)
+		diags.Append(existing.ElementsAs(ctx, &existingComponents, false)...)
+		if diags.HasError() {
+			return nil
+		}
+
+		for compType, compValue := range existingComponents {
+			if compValue.IsNull() {
+				componentMap[compType] = types.StringNull()
+			}
+		}
+	}
+
+	for compType, compList := range apiComponents {
+		if len(compList) == 0 {
+			continue
+		}
+
+		componentID := strings.TrimSpace(compList[0].ID)
+		if componentID == "" {
+			continue
+		}
+
+		componentMap[compType] = types.StringValue(componentID)
+	}
+
+	tfMap, tfDiags := types.MapValue(types.StringType, componentMap)
+	diags.Append(tfDiags...)
+	if diags.HasError() {
+		return nil
+	}
+
+	return &tfMap
 }
 
 func (r *StackResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
@@ -228,32 +320,14 @@ func (r *StackResource) Create(ctx context.Context, req resource.CreateRequest, 
 		return
 	}
 
-	components := make(map[string][]string)
-	if !data.Components.IsNull() {
-		componentElements := make(map[string]types.String, len(data.Components.Elements()))
-		resp.Diagnostics.Append(data.Components.ElementsAs(ctx, &componentElements, false)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
-
-		for compType, compID := range componentElements {
-			if !compID.IsNull() && !compID.IsUnknown() && compID.ValueString() != "" {
-				components[compType] = []string{compID.ValueString()}
-			}
-		}
+	components := expandStackComponentsFromTF(ctx, data.Components, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
-	labels := make(map[string]string)
-	if !data.Labels.IsNull() {
-		labelElements := make(map[string]types.String, len(data.Labels.Elements()))
-		resp.Diagnostics.Append(data.Labels.ElementsAs(ctx, &labelElements, false)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
-
-		for k, v := range labelElements {
-			labels[k] = v.ValueString()
-		}
+	labels := expandStringMapFromTF(ctx, data.Labels, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
 	stackReq := StackRequest{
@@ -318,32 +392,14 @@ func (r *StackResource) Update(ctx context.Context, req resource.UpdateRequest, 
 		return
 	}
 
-	components := make(map[string][]string)
-	if !data.Components.IsNull() {
-		componentElements := make(map[string]types.String, len(data.Components.Elements()))
-		resp.Diagnostics.Append(data.Components.ElementsAs(ctx, &componentElements, false)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
-
-		for compType, compID := range componentElements {
-			if !compID.IsNull() && !compID.IsUnknown() && compID.ValueString() != "" {
-				components[compType] = []string{compID.ValueString()}
-			}
-		}
+	components := expandStackComponentsFromTF(ctx, data.Components, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
-	labels := make(map[string]string)
-	if !data.Labels.IsNull() {
-		labelElements := make(map[string]types.String, len(data.Labels.Elements()))
-		resp.Diagnostics.Append(data.Labels.ElementsAs(ctx, &labelElements, false)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
-
-		for k, v := range labelElements {
-			labels[k] = v.ValueString()
-		}
+	labels := expandStringMapFromTF(ctx, data.Labels, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
 	updateReq := StackUpdate{

--- a/internal/provider/resource_stack_component.go
+++ b/internal/provider/resource_stack_component.go
@@ -438,9 +438,70 @@ func (r *StackComponentResource) Delete(ctx context.Context, req resource.Delete
 
 	tflog.Trace(ctx, "deleting stack component")
 
-	err := r.client.DeleteComponent(ctx, data.ID.ValueString())
+	stacks, err := r.client.ListStacksByComponent(ctx, data.ID.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete stack component, got error: %s", err))
+		resp.Diagnostics.AddError(
+			"Client Error",
+			fmt.Sprintf("Unable to list stacks using component: %s", err),
+		)
+		return
+	}
+
+	componentType := data.Type.ValueString()
+
+	if len(stacks) > 0 {
+		if requiredComponentTypes[componentType] {
+			stackNames := make([]string, len(stacks))
+			for i, s := range stacks {
+				stackNames[i] = s.Name
+			}
+			resp.Diagnostics.AddError(
+				"Component In Use",
+				fmt.Sprintf(
+					"Cannot delete %s component '%s' because it is used by %d "+
+						"stack(s): %v. The %s component type is required and "+
+						"cannot be removed from stacks. The stack(s) must be "+
+						"replaced or deleted first.",
+					componentType,
+					data.Name.ValueString(),
+					len(stacks),
+					stackNames,
+					componentType,
+				),
+			)
+			return
+		}
+
+		componentID := data.ID.ValueString()
+		for _, stack := range stacks {
+			tflog.Info(ctx, fmt.Sprintf(
+				"Removing %s component %s from stack %s before deletion",
+				componentType,
+				componentID,
+				stack.Name,
+			))
+			if err := r.client.RemoveComponentFromStack(
+				ctx, stack.ID, componentID,
+			); err != nil {
+				resp.Diagnostics.AddError(
+					"Client Error",
+					fmt.Sprintf(
+						"Unable to remove component from stack %s: %s",
+						stack.Name,
+						err,
+					),
+				)
+				return
+			}
+		}
+	}
+
+	err = r.client.DeleteComponent(ctx, data.ID.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Client Error",
+			fmt.Sprintf("Unable to delete stack component: %s", err),
+		)
 		return
 	}
 }

--- a/internal/provider/resource_stack_helpers_test.go
+++ b/internal/provider/resource_stack_helpers_test.go
@@ -1,0 +1,107 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestExpandStackComponentsFromTF_IgnoresEmptyAndUnknownValues(t *testing.T) {
+	ctx := context.Background()
+
+	input, diags := types.MapValue(types.StringType, map[string]attr.Value{
+		"artifact_store": types.StringValue("  component-1  "),
+		"orchestrator":   types.StringNull(),
+		"step_operator":  types.StringValue(""),
+	})
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics creating input map: %v", diags)
+	}
+
+	var testDiags diag.Diagnostics
+	got := expandStackComponentsFromTF(ctx, input, &testDiags)
+	if testDiags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", testDiags)
+	}
+
+	if len(got) != 1 {
+		t.Fatalf("expected 1 component, got %d (%v)", len(got), got)
+	}
+	if len(got["artifact_store"]) != 1 || got["artifact_store"][0] != "component-1" {
+		t.Fatalf("unexpected artifact_store expansion: %#v", got["artifact_store"])
+	}
+}
+
+func TestFlattenStackComponentsToTFMap_PreservesNullAndIgnoresEmptyAPIEntries(t *testing.T) {
+	ctx := context.Background()
+	resource := &StackResource{}
+
+	existing, diags := types.MapValue(types.StringType, map[string]attr.Value{
+		"experiment_tracker": types.StringNull(),
+		"orchestrator":       types.StringValue("old-orchestrator"),
+	})
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics creating existing map: %v", diags)
+	}
+
+	var testDiags diag.Diagnostics
+	gotPtr := resource.flattenStackComponentsToTFMap(ctx, map[string][]ComponentResponse{
+		"artifact_store":     {{ID: "artifact-1"}},
+		"orchestrator":       {{ID: "new-orchestrator"}},
+		"container_registry": {},
+		"image_builder":      {{ID: "  "}},
+	}, existing, &testDiags)
+	if testDiags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", testDiags)
+	}
+	if gotPtr == nil {
+		t.Fatal("expected flattened map, got nil")
+	}
+
+	gotElems := make(map[string]types.String)
+	testDiags = nil
+	testDiags.Append(gotPtr.ElementsAs(ctx, &gotElems, false)...)
+	if testDiags.HasError() {
+		t.Fatalf("unexpected diagnostics decoding output map: %v", testDiags)
+	}
+
+	if _, ok := gotElems["container_registry"]; ok {
+		t.Fatalf("expected empty API list to be ignored, got container_registry=%v", gotElems["container_registry"])
+	}
+	if _, ok := gotElems["image_builder"]; ok {
+		t.Fatalf("expected blank API ID to be ignored, got image_builder=%v", gotElems["image_builder"])
+	}
+	if gotElems["artifact_store"].ValueString() != "artifact-1" {
+		t.Fatalf("unexpected artifact_store value: %q", gotElems["artifact_store"].ValueString())
+	}
+	if gotElems["orchestrator"].ValueString() != "new-orchestrator" {
+		t.Fatalf("unexpected orchestrator value: %q", gotElems["orchestrator"].ValueString())
+	}
+	if val, ok := gotElems["experiment_tracker"]; !ok || !val.IsNull() {
+		t.Fatalf("expected null experiment_tracker placeholder to be preserved, got %v (present=%v)", val, ok)
+	}
+}
+
+func TestFlattenStringMapToTFMap_EmptiesExistingLabels(t *testing.T) {
+	existing, diags := types.MapValue(types.StringType, map[string]attr.Value{
+		"environment": types.StringValue("prod"),
+	})
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics creating existing labels map: %v", diags)
+	}
+
+	var testDiags diag.Diagnostics
+	gotPtr := flattenStringMapToTFMap(map[string]string{}, existing, &testDiags)
+	if testDiags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", testDiags)
+	}
+	if gotPtr == nil {
+		t.Fatal("expected null labels map result, got nil")
+	}
+	if !gotPtr.IsNull() {
+		t.Fatalf("expected null labels map, got %#v", *gotPtr)
+	}
+}

--- a/internal/provider/resource_stack_helpers_test.go
+++ b/internal/provider/resource_stack_helpers_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -103,5 +104,126 @@ func TestFlattenStringMapToTFMap_EmptiesExistingLabels(t *testing.T) {
 	}
 	if !gotPtr.IsNull() {
 		t.Fatalf("expected null labels map, got %#v", *gotPtr)
+	}
+}
+
+func TestRequiredComponentTypes_ContainsExpectedTypes(t *testing.T) {
+	if !requiredComponentTypes["orchestrator"] {
+		t.Error("orchestrator should be a required component type")
+	}
+	if !requiredComponentTypes["artifact_store"] {
+		t.Error("artifact_store should be a required component type")
+	}
+	if requiredComponentTypes["container_registry"] {
+		t.Error("container_registry should NOT be a required component type")
+	}
+	if requiredComponentTypes["image_builder"] {
+		t.Error("image_builder should NOT be a required component type")
+	}
+}
+
+func TestRequiresReplaceIfRequiredComponentChanges_OrchestratorChange(t *testing.T) {
+	ctx := context.Background()
+	modifier := requiresReplaceIfRequiredComponentChanges{}
+
+	stateValue, _ := types.MapValue(types.StringType, map[string]attr.Value{
+		"orchestrator":   types.StringValue("old-orch-id"),
+		"artifact_store": types.StringValue("store-id"),
+	})
+	planValue, _ := types.MapValue(types.StringType, map[string]attr.Value{
+		"orchestrator":   types.StringValue("new-orch-id"),
+		"artifact_store": types.StringValue("store-id"),
+	})
+
+	req := planmodifier.MapRequest{
+		StateValue: stateValue,
+		PlanValue:  planValue,
+	}
+	resp := &planmodifier.MapResponse{}
+
+	modifier.PlanModifyMap(ctx, req, resp)
+
+	if !resp.RequiresReplace {
+		t.Error("expected RequiresReplace=true when orchestrator changes")
+	}
+}
+
+func TestRequiresReplaceIfRequiredComponentChanges_ArtifactStoreChange(t *testing.T) {
+	ctx := context.Background()
+	modifier := requiresReplaceIfRequiredComponentChanges{}
+
+	stateValue, _ := types.MapValue(types.StringType, map[string]attr.Value{
+		"orchestrator":   types.StringValue("orch-id"),
+		"artifact_store": types.StringValue("old-store-id"),
+	})
+	planValue, _ := types.MapValue(types.StringType, map[string]attr.Value{
+		"orchestrator":   types.StringValue("orch-id"),
+		"artifact_store": types.StringValue("new-store-id"),
+	})
+
+	req := planmodifier.MapRequest{
+		StateValue: stateValue,
+		PlanValue:  planValue,
+	}
+	resp := &planmodifier.MapResponse{}
+
+	modifier.PlanModifyMap(ctx, req, resp)
+
+	if !resp.RequiresReplace {
+		t.Error("expected RequiresReplace=true when artifact_store changes")
+	}
+}
+
+func TestRequiresReplaceIfRequiredComponentChanges_OptionalComponentChange(t *testing.T) {
+	ctx := context.Background()
+	modifier := requiresReplaceIfRequiredComponentChanges{}
+
+	stateValue, _ := types.MapValue(types.StringType, map[string]attr.Value{
+		"orchestrator":       types.StringValue("orch-id"),
+		"artifact_store":     types.StringValue("store-id"),
+		"container_registry": types.StringValue("old-registry-id"),
+	})
+	planValue, _ := types.MapValue(types.StringType, map[string]attr.Value{
+		"orchestrator":       types.StringValue("orch-id"),
+		"artifact_store":     types.StringValue("store-id"),
+		"container_registry": types.StringValue("new-registry-id"),
+	})
+
+	req := planmodifier.MapRequest{
+		StateValue: stateValue,
+		PlanValue:  planValue,
+	}
+	resp := &planmodifier.MapResponse{}
+
+	modifier.PlanModifyMap(ctx, req, resp)
+
+	if resp.RequiresReplace {
+		t.Error("expected RequiresReplace=false when only optional component changes")
+	}
+}
+
+func TestRequiresReplaceIfRequiredComponentChanges_NoChange(t *testing.T) {
+	ctx := context.Background()
+	modifier := requiresReplaceIfRequiredComponentChanges{}
+
+	stateValue, _ := types.MapValue(types.StringType, map[string]attr.Value{
+		"orchestrator":   types.StringValue("orch-id"),
+		"artifact_store": types.StringValue("store-id"),
+	})
+	planValue, _ := types.MapValue(types.StringType, map[string]attr.Value{
+		"orchestrator":   types.StringValue("orch-id"),
+		"artifact_store": types.StringValue("store-id"),
+	})
+
+	req := planmodifier.MapRequest{
+		StateValue: stateValue,
+		PlanValue:  planValue,
+	}
+	resp := &planmodifier.MapResponse{}
+
+	modifier.PlanModifyMap(ctx, req, resp)
+
+	if resp.RequiresReplace {
+		t.Error("expected RequiresReplace=false when nothing changes")
 	}
 }

--- a/internal/provider/resource_stack_test.go
+++ b/internal/provider/resource_stack_test.go
@@ -79,7 +79,7 @@ func TestAccStack_noopReapplyDoesNotReplace(t *testing.T) {
 	})
 }
 
-func TestAccStack_updateComponentsInPlace(t *testing.T) {
+func TestAccStack_updateRequiredComponentReplacesStack(t *testing.T) {
 	var stackID string
 
 	resource.Test(t, resource.TestCase{
@@ -100,11 +100,35 @@ func TestAccStack_updateComponentsInPlace(t *testing.T) {
 			{
 				Config: testAccStackConfig_withTwoOrchestrators(true),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckResourceAttrEquals("zenml_stack.test", "id", &stackID),
+					testAccCheckResourceAttrChanged("zenml_stack.test", "id", &stackID),
 					resource.TestCheckResourceAttrPair(
 						"zenml_stack.test", "components.orchestrator",
 						"zenml_stack_component.orchestrator_b", "id",
 					),
+				),
+			},
+		},
+	})
+}
+
+func TestAccStack_updateOptionalComponentInPlace(t *testing.T) {
+	var stackID string
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccStackConfig_withOptionalComponent(false),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("zenml_stack.test", "name", "test-stack"),
+					testAccCaptureResourceAttr("zenml_stack.test", "id", &stackID),
+				),
+			},
+			{
+				Config: testAccStackConfig_withOptionalComponent(true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckResourceAttrEquals("zenml_stack.test", "id", &stackID),
 				),
 			},
 		},
@@ -144,6 +168,30 @@ func testAccCheckResourceAttrEquals(resourceName, attr string, expected *string)
 			return fmt.Errorf("attribute %s on %s mismatch: got %q want %q", attr, resourceName, value, *expected)
 		}
 
+		return nil
+	}
+}
+
+func testAccCheckResourceAttrChanged(resourceName, attr string, previous *string) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+		rs, ok := state.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource %s not found in state", resourceName)
+		}
+
+		value, ok := rs.Primary.Attributes[attr]
+		if !ok {
+			return fmt.Errorf("attribute %s missing on resource %s", attr, resourceName)
+		}
+
+		if value == *previous {
+			return fmt.Errorf(
+				"attribute %s on %s should have changed but still equals %q",
+				attr, resourceName, *previous,
+			)
+		}
+
+		*previous = value
 		return nil
 	}
 }
@@ -263,4 +311,57 @@ resource "zenml_stack" "test" {
   }
 }
 `, testAccProviderConfig(), orchestratorRef)
+}
+
+func testAccStackConfig_withOptionalComponent(useSecond bool) string {
+	imageBuilderRef := "zenml_stack_component.image_builder_a.id"
+	if useSecond {
+		imageBuilderRef = "zenml_stack_component.image_builder_b.id"
+	}
+
+	return fmt.Sprintf(`
+%s
+
+resource "zenml_stack_component" "artifact_store" {
+  name   = "test-store-opt"
+  type   = "artifact_store"
+  flavor = "local"
+
+  configuration = {
+    path = "/tmp/artifacts"
+  }
+}
+
+resource "zenml_stack_component" "orchestrator" {
+  name   = "test-orchestrator-opt"
+  type   = "orchestrator"
+  flavor = "local"
+}
+
+resource "zenml_stack_component" "image_builder_a" {
+  name   = "test-image-builder-a"
+  type   = "image_builder"
+  flavor = "local"
+}
+
+resource "zenml_stack_component" "image_builder_b" {
+  name   = "test-image-builder-b"
+  type   = "image_builder"
+  flavor = "local"
+}
+
+resource "zenml_stack" "test" {
+  name = "test-stack"
+
+  components = {
+    artifact_store = zenml_stack_component.artifact_store.id
+    orchestrator   = zenml_stack_component.orchestrator.id
+    image_builder  = %s
+  }
+
+  labels = {
+    environment = "test"
+  }
+}
+`, testAccProviderConfig(), imageBuilderRef)
 }

--- a/internal/provider/resource_stack_test.go
+++ b/internal/provider/resource_stack_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestAccStack_basic(t *testing.T) {
@@ -33,6 +34,8 @@ func TestAccStack_basic(t *testing.T) {
 }
 
 func TestAccStack_update(t *testing.T) {
+	var stackID string
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -42,6 +45,7 @@ func TestAccStack_update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						"zenml_stack.test", "name", "test-stack"),
+					testAccCaptureResourceAttr("zenml_stack.test", "id", &stackID),
 				),
 			},
 			{
@@ -51,10 +55,97 @@ func TestAccStack_update(t *testing.T) {
 						"zenml_stack.test", "name", "updated-stack"),
 					resource.TestCheckResourceAttr(
 						"zenml_stack.test", "labels.environment", "production"),
+					testAccCheckResourceAttrEquals("zenml_stack.test", "id", &stackID),
 				),
 			},
 		},
 	})
+}
+
+func TestAccStack_noopReapplyDoesNotReplace(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccStackConfig_basic(),
+			},
+			{
+				Config:             testAccStackConfig_basic(),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+func TestAccStack_updateComponentsInPlace(t *testing.T) {
+	var stackID string
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccStackConfig_withTwoOrchestrators(false),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("zenml_stack.test", "name", "test-stack"),
+					testAccCaptureResourceAttr("zenml_stack.test", "id", &stackID),
+					resource.TestCheckResourceAttrPair(
+						"zenml_stack.test", "components.orchestrator",
+						"zenml_stack_component.orchestrator_a", "id",
+					),
+				),
+			},
+			{
+				Config: testAccStackConfig_withTwoOrchestrators(true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckResourceAttrEquals("zenml_stack.test", "id", &stackID),
+					resource.TestCheckResourceAttrPair(
+						"zenml_stack.test", "components.orchestrator",
+						"zenml_stack_component.orchestrator_b", "id",
+					),
+				),
+			},
+		},
+	})
+}
+
+func testAccCaptureResourceAttr(resourceName, attr string, dest *string) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+		rs, ok := state.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource %s not found in state", resourceName)
+		}
+
+		value, ok := rs.Primary.Attributes[attr]
+		if !ok {
+			return fmt.Errorf("attribute %s missing on resource %s", attr, resourceName)
+		}
+
+		*dest = value
+		return nil
+	}
+}
+
+func testAccCheckResourceAttrEquals(resourceName, attr string, expected *string) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+		rs, ok := state.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource %s not found in state", resourceName)
+		}
+
+		value, ok := rs.Primary.Attributes[attr]
+		if !ok {
+			return fmt.Errorf("attribute %s missing on resource %s", attr, resourceName)
+		}
+
+		if value != *expected {
+			return fmt.Errorf("attribute %s on %s mismatch: got %q want %q", attr, resourceName, value, *expected)
+		}
+
+		return nil
+	}
 }
 
 func testAccStackConfig_basic() string {
@@ -65,7 +156,7 @@ resource "zenml_stack_component" "artifact_store" {
   name   = "test-store"
   type   = "artifact_store"
   flavor = "local"
-  
+
   configuration = {
     path = "/tmp/artifacts"
   }
@@ -79,12 +170,12 @@ resource "zenml_stack_component" "orchestrator" {
 
 resource "zenml_stack" "test" {
   name = "test-stack"
-  
+
   components = {
     "artifact_store" = zenml_stack_component.artifact_store.id
     "orchestrator"   = zenml_stack_component.orchestrator.id
   }
-  
+
   labels = {
     environment = "test"
   }
@@ -100,7 +191,7 @@ resource "zenml_stack_component" "artifact_store" {
   name   = "test-store"
   type   = "artifact_store"
   flavor = "local"
-  
+
   configuration = {
     path = "/tmp/artifacts"
   }
@@ -126,4 +217,50 @@ resource "zenml_stack" "test" {
   }
 }
 `, testAccProviderConfig())
+}
+
+func testAccStackConfig_withTwoOrchestrators(useSecond bool) string {
+	orchestratorRef := "zenml_stack_component.orchestrator_a.id"
+	if useSecond {
+		orchestratorRef = "zenml_stack_component.orchestrator_b.id"
+	}
+
+	return fmt.Sprintf(`
+%s
+
+resource "zenml_stack_component" "artifact_store" {
+  name   = "test-store"
+  type   = "artifact_store"
+  flavor = "local"
+
+  configuration = {
+    path = "/tmp/artifacts"
+  }
+}
+
+resource "zenml_stack_component" "orchestrator_a" {
+  name   = "test-orchestrator-a"
+  type   = "orchestrator"
+  flavor = "local"
+}
+
+resource "zenml_stack_component" "orchestrator_b" {
+  name   = "test-orchestrator-b"
+  type   = "orchestrator"
+  flavor = "local"
+}
+
+resource "zenml_stack" "test" {
+  name = "test-stack"
+
+  components = {
+    artifact_store = zenml_stack_component.artifact_store.id
+    orchestrator   = %s
+  }
+
+  labels = {
+    environment = "test"
+  }
+}
+`, testAccProviderConfig(), orchestratorRef)
 }

--- a/internal/provider/validation.go
+++ b/internal/provider/validation.go
@@ -100,6 +100,13 @@ var (
 		"deployer",
 		"log_store",
 	}
+
+	// requiredComponentTypes lists component types that cannot be removed from
+	// a stack. These are mandatory for every ZenML stack.
+	requiredComponentTypes = map[string]bool{
+		"orchestrator":   true,
+		"artifact_store": true,
+	}
 )
 
 func NormalizeServerConfig(raw map[string]interface{}) map[string]string {


### PR DESCRIPTION
# Stack Component Deletion Circular Dependency Fix

This PR removes the forced replacement behaviour on zenml_stack.components and uses the existing in-place stack update path instead. Previously, Terraform could delete and recreate ZenML stacks during re-apply, which breaks snapshot-to-stack links and causes outages if apply fails between delete and recreate.

## Problem Analysis

The issue stems from Terraform's execution order conflicting with ZenML's referential integrity:

```mermaid
sequenceDiagram
    participant TF as Terraform
    participant Provider as ZenML Provider
    participant API as ZenML API
    
    TF->>Provider: Delete old component
    Provider->>API: DELETE /components/{id}
    API-->>Provider: Error: component in use by stack
    Provider-->>TF: Deletion failed
    Note over TF: Stack update never happens
```

The API validates this constraint in [`sql_zen_store.py`](zenml/src/zenml/zen_stores/sql_zen_store.py) lines 3727-3736.

## Key Constraint: Required vs Optional Component Types

ZenML stacks have **required** component types that cannot be removed:

- `orchestrator` - always required
- `artifact_store` - always required

All other component types are **optional** and can be removed from a stack.

This constraint drives a **type-aware deletion strategy**:

```mermaid
flowchart TD
    A[Delete component called] --> B[Query stacks using this component]
    B --> C{Component type?}
    C -->|Required: orchestrator, artifact_store| D[Cannot remove from stacks]
    D --> E[Stack must be replaced first]
    E --> F[Fail with clear error message]
    C -->|Optional: all others| G[Remove component from all stacks]
    G --> H[Delete component]
    H --> I[Done]
```

---

## Solution: Type-Aware Deletion with Conditional Stack Replacement

### Part 1: Proactive Stack Dissociation for Optional Components

In `StackComponentResource.Delete()`:

1. **Always** query stacks using the component via `component_id` filter (proactive, not reactive)
2. If stacks exist and component type is **optional**: remove component from each stack, then delete
3. If stacks exist and component type is **required**: return error instructing user that stack must be replaced


### Part 2: Conditional RequiresReplace on Stack Resource

For required component types, the **stack** should be replaced when its orchestrator or artifact_store changes. This uses `RequiresReplaceIf()` plan modifier.

## Behavior Summary

| Component Type | Stacks Exist? | Behavior |
|----------------|---------------|----------|
| Optional (e.g., `container_registry`) | Yes | Remove from stacks, then delete |
| Optional | No | Delete directly |
| Required (`orchestrator`, `artifact_store`) | Yes | Error - stack must be replaced |
| Required | No | Delete directly |
| Stack Component Change | Behavior |
|------------------------|----------|
| `orchestrator` ID changes | Stack replaced (new UUID) |
| `artifact_store` ID changes | Stack replaced (new UUID) |
| Other component ID changes | Stack updated in-place (same UUID) |

---