### PR TITLE
Add basic CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,67 @@
+# CI workflow for the Terraform ZenML provider.
+# Runs on every push to main and on all pull requests.
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+      - run: go mod download
+      - run: go build -v .
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+      - uses: golangci/golangci-lint-action@v7
+        with:
+          version: v2.1.6
+
+  generate:
+    name: Generated docs up to date
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_wrapper: false
+      - run: make docs
+      - name: Verify no diff
+        run: |
+          git diff --compact-summary --exit-code || \
+            (echo "::error::Generated docs are out of date. Run 'make docs' and commit the result." && exit 1)
+
+  test:
+    name: Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+      - run: go test -v -count=1 -timeout 5m ./...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,30 @@
+version: "2"
+
+linters:
+  default: standard
+  settings:
+    errcheck:
+      exclude-functions:
+        # The error from closing an HTTP response body is almost never
+        # meaningful and checking it everywhere adds noise.
+        - (io.Closer).Close
+    govet:
+      disable:
+        - fieldalignment
+        - shadow
+    staticcheck:
+      checks:
+        - "all"
+        - "-ST1000" # package comments — not required for every file
+        - "-ST1003" # naming conventions — Terraform providers use underscores in test helpers by convention
+        - "-ST1005" # error string casing — user-facing Terraform messages use capitalized sentences
+        - "-ST1020" # method comment format — section-header comments are fine
+
+formatters:
+  enable:
+    - gofmt
+    - goimports
+
+issues:
+  max-issues-per-linter: 50
+  max-same-issues: 10

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,24 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+`main.go` is the provider entrypoint. Core implementation lives in `internal/provider/`, with files grouped by concern: `resource_*.go`, `data_source_*.go`, `provider.go`, `client.go`, and shared models/validation helpers. Tests sit beside the code in `*_test.go` files. Generated provider docs live under `docs/resources/` and `docs/data-sources/`, while longer how-to material lives in `docs/guides/`. Example Terraform configurations are in `examples/`; image assets are in `assets/`.
+
+## Build, Test, and Development Commands
+Use the `Makefile` for common workflows:
+
+- `make build`: compile `terraform-provider-zenml`
+- `make test`: run the Go test suite locally
+- `make testacc`: run acceptance tests with `TF_ACC=1` and a live ZenML server
+- `make lint`: run `golangci-lint`
+- `make fmt`: apply `gofmt` and `goimports` through `golangci-lint`
+- `make docs`: regenerate provider documentation after schema changes
+- `make install`: copy the built provider into the local Terraform plugin directory
+
+## Coding Style & Naming Conventions
+This is a Go module targeting the version declared in `go.mod`. Follow standard Go formatting: tabs for indentation, short receiver names, and `gofmt`/`goimports` output as the source of truth. Keep file names descriptive and aligned with Terraform concepts, for example `resource_stack.go` or `data_source_server.go`. Use exported CamelCase names for framework-facing types and unexported helpers for internal-only logic.
+
+## Testing Guidelines
+Use `make test` for fast feedback and `make testacc` for changes that touch API behavior, lifecycle handling, or Terraform state transitions. Acceptance tests follow the `TestAcc...` naming pattern; focused unit tests use regular `Test...` names. Set `ZENML_SERVER_URL` and either `ZENML_API_KEY` or `ZENML_API_TOKEN` before running acceptance coverage. There is no published coverage threshold, so add tests for every new resource/data source path you change.
+
+## Commit & Pull Request Guidelines
+Recent history favors short, imperative commit messages such as `Fix updates to include all fields even when empty` or `Add log store to the supported component types`. Keep commits targeted and stage only relevant files. PRs should include a clear description, test coverage, and any required README or `docs/` updates. If provider schemas change, run `make docs` and commit the generated files; CI checks that generated docs are up to date.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,96 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Terraform provider for managing ZenML resources (stacks, stack components, service connectors, projects) via Infrastructure as Code. Built with the **HashiCorp Terraform Plugin Framework** (not the older SDKv2). Communicates with the ZenML server REST API (`/api/v1/...`).
+
+## Build & Development Commands
+
+```bash
+make build          # Build the provider binary
+make test           # Run unit tests (no server needed)
+make testacc        # Run acceptance tests (requires ZENML_SERVER_URL + ZENML_API_KEY)
+make lint           # Run golangci-lint (v2, config in .golangci.yml)
+make fmt            # Run formatter check
+make docs           # Generate provider documentation (go generate)
+make install        # Install provider to local Terraform plugins dir
+make clean          # Remove build artifacts
+```
+
+Run a single test:
+```bash
+go test ./internal/provider/ -run TestExpandStackComponentsFromTF -v
+```
+
+Acceptance tests require env vars:
+```bash
+export ZENML_SERVER_URL="https://your-server"
+export ZENML_API_KEY="your-key"
+make testacc
+```
+
+## Architecture
+
+All provider code lives in **one package**: `internal/provider/`. There is no separate client package.
+
+### Key Files
+
+- **`main.go`** — Entry point. Wires up `providerserver.Serve` with the provider factory.
+- **`provider.go`** — `ZenMLProvider` struct, schema (server_url, api_key, api_token, skip_version_check), and `Configure()` which creates the API client and validates server version (>= 0.80.0).
+- **`client.go`** — HTTP client for the ZenML REST API. Handles API key → token exchange via `/api/v1/login`, token expiry/refresh, and all CRUD operations for stacks, components, connectors, and projects.
+- **`models.go`** — Go structs mirroring ZenML API request/response shapes. API responses use a nested `Body`/`Metadata` envelope pattern (e.g., `StackResponse.Body.Created`, `StackResponse.Metadata.Components`).
+- **`validation.go`** — Valid connector types/auth methods/component types lists, plus `MergeOrCompareConfiguration()` for reconciling Terraform state with server-mutated config.
+
+### Resources (CRUD)
+
+| Resource | File | Notes |
+|---|---|---|
+| `zenml_stack` | `resource_stack.go` | Components map is `type→ID`. Changing orchestrator/artifact_store triggers replacement via custom plan modifier. |
+| `zenml_stack_component` | `resource_stack_component.go` | On delete, proactively removes itself from any stacks (unless it's a required type like orchestrator/artifact_store). |
+| `zenml_service_connector` | `resource_service_connector.go` | Supports optional verification with retries and configurable timeouts. `ConnectorType` in API response can be string or object (handled via `json.RawMessage`). |
+| `zenml_project` | `resource_project.go` | Simple CRUD for projects. |
+
+### Data Sources (read-only)
+
+| Data Source | File |
+|---|---|
+| `zenml_server` | `data_source_server.go` |
+| `zenml_stack` | `data_source_stack.go` |
+| `zenml_stack_component` | `data_source_stack_component.go` |
+| `zenml_service_connector` | `data_source_service_connector.go` |
+
+### Important Design Patterns
+
+**Configuration merging**: The ZenML server may mutate component/connector configuration on create/update (e.g., normalizing values, adding defaults). `MergeOrCompareConfiguration()` in `validation.go` ensures user-provided Terraform values are preserved while server-added keys are merged in. This prevents perpetual diffs.
+
+**Required vs optional component types**: `requiredComponentTypes` in `validation.go` defines `orchestrator` and `artifact_store` as mandatory. The custom `requiresReplaceIfRequiredComponentChanges` plan modifier on stacks forces stack replacement when these change, while optional components can be swapped in-place.
+
+**Component deletion lifecycle**: When deleting a `zenml_stack_component`, the provider first checks if it's used by any stacks. For optional component types, it proactively removes the component from those stacks before deletion. For required types, deletion is blocked with an error.
+
+**404 handling**: All `Get*` client methods return `(nil, nil)` on HTTP 404, and all `Delete*` methods silently succeed on 404. Resource `Read` methods remove the resource from state when the API returns nil (drift detection).
+
+## Testing
+
+Two categories of tests:
+- **Unit tests** (`resource_stack_helpers_test.go`): Test expand/flatten helpers and plan modifiers directly. No server needed.
+- **Acceptance tests** (`resource_stack_test.go`, etc.): Use `resource.Test()` from `terraform-plugin-testing`. Require a running ZenML server. Tests use `testAccPreCheck` to verify env vars and `testAccProviderConfig()` for provider configuration.
+
+Test naming convention: `TestAcc*` for acceptance tests, `Test*` for unit tests.
+
+## CI
+
+GitHub Actions (`.github/workflows/ci.yml`) runs on push to main and all PRs:
+1. **Build** — `go build`
+2. **Lint** — `golangci-lint` v2.1.6
+3. **Generate** — Ensures `make docs` output is committed (fails if docs are stale)
+4. **Test** — `go test -v -count=1 -timeout 5m ./...` (unit tests only, no acceptance)
+
+## Linting
+
+Uses golangci-lint v2 (`.golangci.yml`). Default "standard" linter set with `govet` enable-all. Formatters: `gofmt` + `goimports`.
+
+## Release Process
+
+Automated via GitHub Actions on tag push. GoReleaser sets the `version` variable in `main.go`. Tags follow `vX.Y.Z` format. Provider is published to the Terraform Registry under `zenml-io/zenml`.

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,16 @@ install: build
 docs:
 	go generate ./...
 
+# Run linter
+.PHONY: lint
+lint:
+	golangci-lint run
+
+# Run formatter check
+.PHONY: fmt
+fmt:
+	golangci-lint fmt
+
 # Clean build artifacts
 .PHONY: clean
 clean:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Terraform Provider for ZenML
 
-[![Tests](https://github.com/zenml-io/terraform-provider-zenml/actions/workflows/test.yml/badge.svg)](https://github.com/zenml-io/terraform-provider-zenml/actions/workflows/test.yml)
+[![CI](https://github.com/zenml-io/terraform-provider-zenml/actions/workflows/ci.yml/badge.svg)](https://github.com/zenml-io/terraform-provider-zenml/actions/workflows/ci.yml)
 [![Release](https://github.com/zenml-io/terraform-provider-zenml/actions/workflows/release.yml/badge.svg)](https://github.com/zenml-io/terraform-provider-zenml/actions/workflows/release.yml)
 
 This Terraform provider allows you to manage ZenML resources using Infrastructure as Code. It provides the ability to manage:

--- a/internal/provider/client.go
+++ b/internal/provider/client.go
@@ -246,7 +246,7 @@ func (c *Client) DeleteStack(ctx context.Context, id string) error {
 		}
 		return err
 	}
-	resp.Body.Close()
+	defer resp.Body.Close()
 	return nil
 }
 
@@ -406,7 +406,7 @@ func (c *Client) DeleteComponent(ctx context.Context, id string) error {
 		}
 		return err
 	}
-	resp.Body.Close()
+	defer resp.Body.Close()
 	return nil
 }
 
@@ -519,7 +519,7 @@ func (c *Client) DeleteServiceConnector(ctx context.Context, id string) error {
 		}
 		return err
 	}
-	resp.Body.Close()
+	defer resp.Body.Close()
 	return nil
 }
 

--- a/internal/provider/resource_service_connector.go
+++ b/internal/provider/resource_service_connector.go
@@ -275,7 +275,7 @@ func (r *ServiceConnectorResource) buildServiceConnectorRequest(
 		return nil
 	}
 
-	var configuration map[string]interface{} = make(map[string]interface{})
+	configuration := make(map[string]interface{})
 	if !data.Configuration.IsNull() && len(data.Configuration.Elements()) > 0 {
 		configElements := make(map[string]types.String, len(data.Configuration.Elements()))
 		diags.Append(data.Configuration.ElementsAs(ctx, &configElements, false)...)
@@ -288,7 +288,7 @@ func (r *ServiceConnectorResource) buildServiceConnectorRequest(
 		}
 	}
 
-	var labels map[string]string = make(map[string]string)
+	labels := make(map[string]string)
 	if !data.Labels.IsNull() && len(data.Labels.Elements()) > 0 {
 		labelElements := make(map[string]types.String, len(data.Labels.Elements()))
 		diags.Append(data.Labels.ElementsAs(ctx, &labelElements, false)...)


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions CI pipeline (`.github/workflows/ci.yml`) with four parallel jobs: **build**, **lint** (golangci-lint v2), **generate** (verify docs are up to date), and **test**
- Adds `.golangci.yml` config tuned for Terraform provider conventions (disables noisy checks like `fieldalignment`, `shadow`, and style rules that conflict with HashiCorp's test naming conventions)
- Adds `make lint` and `make fmt` targets for local development
- Fixes inconsistent `resp.Body.Close()` usage — all client methods now use `defer` consistently
- Fixes redundant type declarations in `resource_service_connector.go`
- Updates README badge to point to the new CI workflow instead of non-existent `test.yml`

## Test plan

- [x] `go build -v .` passes locally
- [x] `go test -count=1 -timeout 5m ./...` passes locally (9 unit tests pass, 12 acceptance tests correctly skip)
- [x] `golangci-lint run` reports 0 issues
- [ ] CI workflow runs successfully on this PR