### PR TITLE
fix: stack component connector validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 # https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
 #
 # Binaries for programs and plugins
+terraform-provider-zenml
 *.exe
 *.exe~
 *.dll

--- a/internal/provider/resource_stack_component.go
+++ b/internal/provider/resource_stack_component.go
@@ -143,31 +143,18 @@ func (v stackComponentConfigValidator) ValidateResource(ctx context.Context, req
 		return
 	}
 
-	if missingConnectorIDWithResource(data.ConnectorID, data.ConnectorResourceID) {
+	// Check if connector_resource_id is set but connector_id is not. Unknown
+	// connector_id values are allowed because they can be resolved during apply.
+	if !data.ConnectorResourceID.IsNull() && !data.ConnectorResourceID.IsUnknown() &&
+		data.ConnectorResourceID.ValueString() != "" &&
+		(data.ConnectorID.IsNull() ||
+			(!data.ConnectorID.IsUnknown() && data.ConnectorID.ValueString() == "")) {
 		resp.Diagnostics.AddAttributeError(
 			path.Root("connector_id"),
 			"Missing connector_id",
 			"connector_id must be set when connector_resource_id is specified",
 		)
 	}
-}
-
-// missingConnectorIDWithResource returns true only when a component has a
-// concrete connector_resource_id but no concrete connector_id. Terraform may
-// know that connector_id is configured while its value is still unknown until
-// apply, so unknown connector IDs must pass this plan-time validation.
-func missingConnectorIDWithResource(connectorID, connectorResourceID types.String) bool {
-	if connectorResourceID.IsNull() ||
-		connectorResourceID.IsUnknown() ||
-		connectorResourceID.ValueString() == "" {
-		return false
-	}
-
-	if connectorID.IsUnknown() {
-		return false
-	}
-
-	return connectorID.IsNull() || connectorID.ValueString() == ""
 }
 
 func (r *StackComponentResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {

--- a/internal/provider/resource_stack_component.go
+++ b/internal/provider/resource_stack_component.go
@@ -143,16 +143,31 @@ func (v stackComponentConfigValidator) ValidateResource(ctx context.Context, req
 		return
 	}
 
-	// Check if connector_resource_id is set but connector_id is not
-	if !data.ConnectorResourceID.IsNull() && !data.ConnectorResourceID.IsUnknown() &&
-		data.ConnectorResourceID.ValueString() != "" &&
-		(data.ConnectorID.IsNull() || data.ConnectorID.IsUnknown() || data.ConnectorID.ValueString() == "") {
+	if missingConnectorIDWithResource(data.ConnectorID, data.ConnectorResourceID) {
 		resp.Diagnostics.AddAttributeError(
 			path.Root("connector_id"),
 			"Missing connector_id",
 			"connector_id must be set when connector_resource_id is specified",
 		)
 	}
+}
+
+// missingConnectorIDWithResource returns true only when a component has a
+// concrete connector_resource_id but no concrete connector_id. Terraform may
+// know that connector_id is configured while its value is still unknown until
+// apply, so unknown connector IDs must pass this plan-time validation.
+func missingConnectorIDWithResource(connectorID, connectorResourceID types.String) bool {
+	if connectorResourceID.IsNull() ||
+		connectorResourceID.IsUnknown() ||
+		connectorResourceID.ValueString() == "" {
+		return false
+	}
+
+	if connectorID.IsUnknown() {
+		return false
+	}
+
+	return connectorID.IsNull() || connectorID.ValueString() == ""
 }
 
 func (r *StackComponentResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {

--- a/internal/provider/resource_stack_component_test.go
+++ b/internal/provider/resource_stack_component_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
@@ -94,66 +93,6 @@ func TestAccStackComponent_withConfiguration(t *testing.T) {
 			},
 		},
 	})
-}
-
-// TestMissingConnectorIDWithResource covers the validator helper that enforces
-// connector_id only when connector_resource_id is known and set. The unknown
-// connector_id case protects configs where the ID comes from a connector
-// resource being created in the same apply.
-func TestMissingConnectorIDWithResource(t *testing.T) {
-	tests := map[string]struct {
-		connectorID         types.String
-		connectorResourceID types.String
-		want                bool
-	}{
-		"resource_id unset": {
-			connectorID:         types.StringNull(),
-			connectorResourceID: types.StringNull(),
-			want:                false,
-		},
-		"resource_id unknown": {
-			connectorID:         types.StringNull(),
-			connectorResourceID: types.StringUnknown(),
-			want:                false,
-		},
-		"resource_id empty": {
-			connectorID:         types.StringNull(),
-			connectorResourceID: types.StringValue(""),
-			want:                false,
-		},
-		"connector_id null": {
-			connectorID:         types.StringNull(),
-			connectorResourceID: types.StringValue("bucket"),
-			want:                true,
-		},
-		"connector_id empty": {
-			connectorID:         types.StringValue(""),
-			connectorResourceID: types.StringValue("bucket"),
-			want:                true,
-		},
-		"connector_id unknown": {
-			connectorID:         types.StringUnknown(),
-			connectorResourceID: types.StringValue("bucket"),
-			want:                false,
-		},
-		"connector_id set": {
-			connectorID:         types.StringValue("connector-id"),
-			connectorResourceID: types.StringValue("bucket"),
-			want:                false,
-		},
-	}
-
-	for name, tt := range tests {
-		t.Run(name, func(t *testing.T) {
-			got := missingConnectorIDWithResource(
-				tt.connectorID,
-				tt.connectorResourceID,
-			)
-			if got != tt.want {
-				t.Fatalf("expected %v, got %v", tt.want, got)
-			}
-		})
-	}
 }
 
 func testAccStackComponentConfig_basic() string {

--- a/internal/provider/resource_stack_component_test.go
+++ b/internal/provider/resource_stack_component_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
@@ -93,6 +94,66 @@ func TestAccStackComponent_withConfiguration(t *testing.T) {
 			},
 		},
 	})
+}
+
+// TestMissingConnectorIDWithResource covers the validator helper that enforces
+// connector_id only when connector_resource_id is known and set. The unknown
+// connector_id case protects configs where the ID comes from a connector
+// resource being created in the same apply.
+func TestMissingConnectorIDWithResource(t *testing.T) {
+	tests := map[string]struct {
+		connectorID         types.String
+		connectorResourceID types.String
+		want                bool
+	}{
+		"resource_id unset": {
+			connectorID:         types.StringNull(),
+			connectorResourceID: types.StringNull(),
+			want:                false,
+		},
+		"resource_id unknown": {
+			connectorID:         types.StringNull(),
+			connectorResourceID: types.StringUnknown(),
+			want:                false,
+		},
+		"resource_id empty": {
+			connectorID:         types.StringNull(),
+			connectorResourceID: types.StringValue(""),
+			want:                false,
+		},
+		"connector_id null": {
+			connectorID:         types.StringNull(),
+			connectorResourceID: types.StringValue("bucket"),
+			want:                true,
+		},
+		"connector_id empty": {
+			connectorID:         types.StringValue(""),
+			connectorResourceID: types.StringValue("bucket"),
+			want:                true,
+		},
+		"connector_id unknown": {
+			connectorID:         types.StringUnknown(),
+			connectorResourceID: types.StringValue("bucket"),
+			want:                false,
+		},
+		"connector_id set": {
+			connectorID:         types.StringValue("connector-id"),
+			connectorResourceID: types.StringValue("bucket"),
+			want:                false,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := missingConnectorIDWithResource(
+				tt.connectorID,
+				tt.connectorResourceID,
+			)
+			if got != tt.want {
+				t.Fatalf("expected %v, got %v", tt.want, got)
+			}
+		})
+	}
 }
 
 func testAccStackComponentConfig_basic() string {


### PR DESCRIPTION
Allow connector_id to be unknown during terraform plan when connector_resource_id is set, so stack components can reference service connectors created in the same apply.