### PR TITLE
Add terraform resource for zenml secrets

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,7 @@ The ZenML provider allows you to manage [ZenML](https://zenml.io) resources usin
 - ZenML Stacks
 - Stack Components
 - Service Connectors
+- Secrets
 
 ## Requirements
 
@@ -33,6 +34,20 @@ provider "zenml" {
   # Configuration options will be loaded from environment variables:
   # ZENML_SERVER_URL
   # ZENML_API_KEY
+}
+
+variable "example_api_key" {
+  type      = string
+  sensitive = true
+}
+
+# Create a secret
+resource "zenml_secret" "example" {
+  name = "example-credentials"
+
+  values = {
+    api_key = var.example_api_key
+  }
 }
 
 # Create a service connector
@@ -133,6 +148,7 @@ provider "zenml" {
 
 ## Resources
 
+* [zenml_secret](resources/secret.md) - Manages secrets
 * [zenml_service_connector](resources/service_connector.md) - Manages service connectors for external services
 * [zenml_stack_component](resources/stack_component.md) - Manages stack components
 * [zenml_stack](resources/stack.md) - Manages stacks

--- a/docs/resources/secret.md
+++ b/docs/resources/secret.md
@@ -51,9 +51,7 @@ resource "zenml_stack_component" "databricks" {
 
 * `name` - (Required) The unique name of the secret within its scope.
 * `values` - (Required, Sensitive) A map of values stored in the secret. Removing a key from this map removes it from the ZenML secret.
-* `private` - (Optional) Whether only the user that created the secret can access it. Defaults to `false`. Public secrets are generally preferable for IaC because private secrets are owned by the service account that runs Terraform.
-
-The provider principal must have permission to create, update, and delete secrets, including `READ_SECRET_VALUE`. Terraform cannot refresh or import a secret when its values are redacted.
+* `private` - (Optional) Whether only the user that created the secret can access it. Defaults to `false`.
 
 ## Attributes Reference
 
@@ -69,5 +67,3 @@ Secrets can be imported by UUID:
 ```shell
 terraform import zenml_secret.example 12345678-1234-1234-1234-123456789012
 ```
-
-Import requires `READ_SECRET_VALUE` permission because all values must be loaded into Terraform state.

--- a/docs/resources/secret.md
+++ b/docs/resources/secret.md
@@ -1,0 +1,73 @@
+---
+page_title: "zenml_secret Resource - terraform-provider-zenml"
+subcategory: ""
+description: |-
+  Manages a ZenML secret.
+---
+
+# zenml_secret (Resource)
+
+Manages a ZenML secret whose values can be referenced by stack components and other ZenML resources.
+
+> Secret values are stored in Terraform state. The `sensitive` designation hides them from normal CLI output but does not encrypt them. Use an encrypted, access-controlled remote state backend.
+
+## Example Usage
+
+```hcl
+variable "databricks_client_id" {
+  type      = string
+  sensitive = true
+}
+
+variable "databricks_client_secret" {
+  type      = string
+  sensitive = true
+}
+
+resource "zenml_secret" "databricks" {
+  name    = "databricks-oauth"
+  private = false
+
+  values = {
+    client_id     = var.databricks_client_id
+    client_secret = var.databricks_client_secret
+  }
+}
+
+resource "zenml_stack_component" "databricks" {
+  name   = "databricks-orchestrator"
+  type   = "orchestrator"
+  flavor = "databricks"
+
+  configuration = {
+    host          = "https://example.cloud.databricks.com"
+    client_id     = format("{{%s.client_id}}", zenml_secret.databricks.name)
+    client_secret = format("{{%s.client_secret}}", zenml_secret.databricks.name)
+  }
+}
+```
+
+## Argument Reference
+
+* `name` - (Required) The unique name of the secret within its scope.
+* `values` - (Required, Sensitive) A map of values stored in the secret. Removing a key from this map removes it from the ZenML secret.
+* `private` - (Optional) Whether only the user that created the secret can access it. Defaults to `false`. Public secrets are generally preferable for IaC because private secrets are owned by the service account that runs Terraform.
+
+The provider principal must have permission to create, update, and delete secrets, including `READ_SECRET_VALUE`. Terraform cannot refresh or import a secret when its values are redacted.
+
+## Attributes Reference
+
+* `id` - The secret ID.
+* `user_id` - The ID of the user that owns the secret.
+* `created` - The timestamp when the secret was created.
+* `updated` - The timestamp when the secret was last updated.
+
+## Import
+
+Secrets can be imported by UUID:
+
+```shell
+terraform import zenml_secret.example 12345678-1234-1234-1234-123456789012
+```
+
+Import requires `READ_SECRET_VALUE` permission because all values must be loaded into Terraform state.

--- a/internal/provider/client.go
+++ b/internal/provider/client.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -111,6 +112,8 @@ or use the ZENML_API_KEY environment variable to set the API key.
 
 func (c *Client) doRequest(ctx context.Context, method, path string, body interface{}) (*http.Response, int, error) {
 	var bodyReader io.Reader
+	// secrets endpoints are sensitive and should not be logged
+	sensitivePayload := strings.HasPrefix(path, "/api/v1/secrets")
 
 	if body != nil {
 		jsonBody, err := json.Marshal(body)
@@ -137,7 +140,7 @@ func (c *Client) doRequest(ctx context.Context, method, path string, body interf
 	}
 
 	tflog.Info(ctx, fmt.Sprintf("[ZENML] Making request: %s %s", method, req.URL.String()))
-	if body != nil {
+	if body != nil && !sensitivePayload {
 		prettyJSON, _ := json.MarshalIndent(body, "", "  ")
 		tflog.Debug(ctx, fmt.Sprintf("[ZENML] Request body (JSON):\n%s", prettyJSON))
 	}
@@ -152,7 +155,7 @@ func (c *Client) doRequest(ctx context.Context, method, path string, body interf
 	resp_body, _ := io.ReadAll(resp.Body)
 
 	// Print the response body as JSON if available
-	if len(resp_body) > 0 {
+	if len(resp_body) > 0 && !sensitivePayload {
 		var prettyBody map[string]interface{}
 		if err := json.Unmarshal(resp_body, &prettyBody); err == nil {
 			prettyJSON, _ := json.MarshalIndent(prettyBody, "", "  ")
@@ -165,6 +168,9 @@ func (c *Client) doRequest(ctx context.Context, method, path string, body interf
 	tflog.Info(ctx, fmt.Sprintf("[ZENML] Response status: %d", resp.StatusCode))
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		if sensitivePayload {
+			return nil, resp.StatusCode, fmt.Errorf("API request failed with status %d", resp.StatusCode)
+		}
 		return nil, resp.StatusCode, fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(resp_body))
 	}
 
@@ -652,5 +658,65 @@ func (c *Client) DeleteProject(ctx context.Context, nameOrID string) error {
 		return err
 	}
 	defer resp.Body.Close()
+	return nil
+}
+
+// Secret operations...
+func (c *Client) CreateSecret(ctx context.Context, secret SecretRequest) (*SecretResponse, error) {
+	resp, _, err := c.doRequest(ctx, "POST", "/api/v1/secrets", secret)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var result SecretResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("error decoding secret response: %v", err)
+	}
+	return &result, nil
+}
+
+func (c *Client) GetSecret(ctx context.Context, id string) (*SecretResponse, error) {
+	resp, status, err := c.doRequest(ctx, "GET", fmt.Sprintf("/api/v1/secrets/%s", id), nil)
+	if err != nil {
+		// treats HTTP 404 as "the resource no longer exists"
+		if status == 404 {
+			return nil, nil
+		}
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var result SecretResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("error decoding secret response: %v", err)
+	}
+	return &result, nil
+}
+
+func (c *Client) UpdateSecret(ctx context.Context, id string, secret SecretUpdate) (*SecretResponse, error) {
+	resp, _, err := c.doRequest(ctx, "PUT", fmt.Sprintf("/api/v1/secrets/%s", id), secret)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var result SecretResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("error decoding secret response: %v", err)
+	}
+	return &result, nil
+}
+
+func (c *Client) DeleteSecret(ctx context.Context, id string) error {
+	resp, status, err := c.doRequest(ctx, "DELETE", fmt.Sprintf("/api/v1/secrets/%s", id), nil)
+	if err != nil {
+		// treats HTTP 404 as the secret no longer exists or was never created
+		if status == 404 {
+			return nil
+		}
+		return err
+	}
+	resp.Body.Close()
 	return nil
 }

--- a/internal/provider/models.go
+++ b/internal/provider/models.go
@@ -272,3 +272,32 @@ type ProjectUpdate struct {
 	DisplayName *string `json:"display_name,omitempty"`
 	Description *string `json:"description,omitempty"`
 }
+
+// SecretRequest represents a request to create a ZenML secret.
+type SecretRequest struct {
+	Name    string            `json:"name"`
+	Private bool              `json:"private"`
+	Values  map[string]string `json:"values"`
+}
+
+// SecretUpdate replaces the configurable attributes of a ZenML secret.
+type SecretUpdate struct {
+	Name    string            `json:"name"`
+	Private bool              `json:"private"`
+	Values  map[string]string `json:"values"`
+}
+
+// SecretResponse represents a secret returned by the ZenML API.
+type SecretResponse struct {
+	ID   string              `json:"id"`
+	Name string              `json:"name"`
+	Body *SecretResponseBody `json:"body,omitempty"`
+}
+
+type SecretResponseBody struct {
+	Created string             `json:"created"`
+	Updated string             `json:"updated"`
+	UserID  *string            `json:"user_id,omitempty"`
+	Private bool               `json:"private"`
+	Values  map[string]*string `json:"values"`
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -268,6 +268,7 @@ func (p *ZenMLProvider) Resources(ctx context.Context) []func() resource.Resourc
 		NewStackComponentResource,
 		NewServiceConnectorResource,
 		NewProjectResource,
+		NewSecretResource,
 	}
 }
 

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -81,6 +81,7 @@ func testAccProviderConfig() string {
 provider "zenml" {
   server_url = "` + os.Getenv("ZENML_SERVER_URL") + `"
   api_key    = "` + os.Getenv("ZENML_API_KEY") + `"
+  api_token  = "` + os.Getenv("ZENML_API_TOKEN") + `"
 }
 `
 }

--- a/internal/provider/resource_secret.go
+++ b/internal/provider/resource_secret.go
@@ -129,7 +129,7 @@ func (r *SecretResource) populateSecretModel(
 			diags.AddAttributeError(
 				path.Root("values"),
 				"Unable to Read Secret Values",
-				"The provider principal needs READ_SECRET_VALUE permission to manage or import ZenML secrets.",
+				"ZenML did not return all values for this secret. Ensure the account configured for the provider can read secret values.",
 			)
 			return
 		}

--- a/internal/provider/resource_secret.go
+++ b/internal/provider/resource_secret.go
@@ -1,0 +1,259 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+var _ resource.Resource = &SecretResource{}
+var _ resource.ResourceWithImportState = &SecretResource{}
+
+func NewSecretResource() resource.Resource {
+	return &SecretResource{}
+}
+
+type SecretResource struct {
+	client *Client
+}
+
+type SecretResourceModel struct {
+	ID      types.String `tfsdk:"id"`
+	Name    types.String `tfsdk:"name"`
+	Private types.Bool   `tfsdk:"private"`
+	Values  types.Map    `tfsdk:"values"`
+	UserID  types.String `tfsdk:"user_id"`
+	Created types.String `tfsdk:"created"`
+	Updated types.String `tfsdk:"updated"`
+}
+
+func (r *SecretResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_secret"
+}
+
+func (r *SecretResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		MarkdownDescription: "Manages a ZenML secret. Secret values are stored in Terraform state; use a secured remote backend.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "Secret identifier",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"name": schema.StringAttribute{
+				Required:            true,
+				MarkdownDescription: "Name of the secret",
+				Validators: []validator.String{
+					stringvalidator.LengthBetween(1, 255),
+				},
+			},
+			"private": schema.BoolAttribute{
+				Optional:            true,
+				Computed:            true,
+				MarkdownDescription: "Whether the secret is only accessible to the user that created it",
+				Default:             booldefault.StaticBool(false),
+			},
+			// Sensitive=true hides the value from normal terraform output
+			"values": schema.MapAttribute{
+				Required:            true,
+				Sensitive:           true,
+				ElementType:         types.StringType,
+				MarkdownDescription: "Key-value pairs stored in the secret",
+			},
+			"user_id": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "Identifier of the user that owns the secret",
+			},
+			"created": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "Timestamp when the secret was created",
+			},
+			"updated": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "Timestamp when the secret was last updated",
+			},
+		},
+	}
+}
+
+func (r *SecretResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*Client)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	r.client = client
+}
+
+func secretValuesFromModel(ctx context.Context, data *SecretResourceModel, diags *diag.Diagnostics) map[string]string {
+	values := map[string]string{}
+	diags.Append(data.Values.ElementsAs(ctx, &values, false)...)
+	return values
+}
+
+func (r *SecretResource) populateSecretModel(
+	ctx context.Context,
+	secret *SecretResponse,
+	data *SecretResourceModel,
+	diags *diag.Diagnostics,
+) {
+	if secret.Body == nil {
+		diags.AddError("Invalid API Response", "The ZenML server returned a secret without a response body.")
+		return
+	}
+
+	values := make(map[string]string, len(secret.Body.Values))
+	for key, value := range secret.Body.Values {
+		if value == nil {
+			diags.AddAttributeError(
+				path.Root("values"),
+				"Unable to Read Secret Values",
+				"The provider principal needs READ_SECRET_VALUE permission to manage or import ZenML secrets.",
+			)
+			return
+		}
+		values[key] = *value
+	}
+
+	valueMap, valueDiags := types.MapValueFrom(ctx, types.StringType, values)
+	diags.Append(valueDiags...)
+	if diags.HasError() {
+		return
+	}
+
+	data.ID = types.StringValue(secret.ID)
+	data.Name = types.StringValue(secret.Name)
+	data.Private = types.BoolValue(secret.Body.Private)
+	data.Values = valueMap
+	data.Created = types.StringValue(secret.Body.Created)
+	data.Updated = types.StringValue(secret.Body.Updated)
+	if secret.Body.UserID == nil {
+		data.UserID = types.StringNull()
+	} else {
+		data.UserID = types.StringValue(*secret.Body.UserID)
+	}
+}
+
+func (r *SecretResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data SecretResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	values := secretValuesFromModel(ctx, &data, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	tflog.Trace(ctx, "creating secret")
+	secret, err := r.client.CreateSecret(ctx, SecretRequest{
+		Name:    data.Name.ValueString(),
+		Private: data.Private.ValueBool(),
+		Values:  values,
+	})
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create secret, got error: %s", err))
+		return
+	}
+
+	r.populateSecretModel(ctx, secret, &data, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *SecretResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data SecretResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	secret, err := r.client.GetSecret(ctx, data.ID.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read secret, got error: %s", err))
+		return
+	}
+	// if the secret is not found, the resource was likely deleted outside of Terraform
+	// Terraform will propose to recreate it.
+	if secret == nil {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	r.populateSecretModel(ctx, secret, &data, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *SecretResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data SecretResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	values := secretValuesFromModel(ctx, &data, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	tflog.Trace(ctx, "updating secret")
+	secret, err := r.client.UpdateSecret(ctx, data.ID.ValueString(), SecretUpdate{
+		Name:    data.Name.ValueString(),
+		Private: data.Private.ValueBool(),
+		Values:  values,
+	})
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update secret, got error: %s", err))
+		return
+	}
+
+	r.populateSecretModel(ctx, secret, &data, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *SecretResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data SecretResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	tflog.Trace(ctx, "deleting secret")
+	if err := r.client.DeleteSecret(ctx, data.ID.ValueString()); err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete secret, got error: %s", err))
+	}
+}
+
+func (r *SecretResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}

--- a/internal/provider/resource_secret_test.go
+++ b/internal/provider/resource_secret_test.go
@@ -1,0 +1,135 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+/*
+TestAccSecret_basic verifies the complete Terraform resource lifecycle:
+1. Create a public secret with two values and a server-generated ID.
+2. Rename the secret and change it from public to private.
+3. Update one value and remove another through full-replacement semantics.
+4. Import the secret by UUID and verify that the imported state matches.
+5. Delete the secret during Terraform's automatic test cleanup.
+*/
+
+func TestAccSecret_basic(t *testing.T) {
+	name := "terraform-test-" + acctest.RandString(8)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccSecretPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSecretConfig(name, false, map[string]string{
+					"client_id":     "test-client",
+					"client_secret": "test-secret",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("zenml_secret.test", "name", name),
+					resource.TestCheckResourceAttr("zenml_secret.test", "private", "false"),
+					resource.TestCheckResourceAttr("zenml_secret.test", "values.%", "2"),
+					resource.TestCheckResourceAttr("zenml_secret.test", "values.client_secret", "test-secret"),
+					resource.TestCheckResourceAttrSet("zenml_secret.test", "id"),
+				),
+			},
+			{
+				Config: testAccSecretConfig(name+"-updated", true, map[string]string{
+					"client_id": "updated-client",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("zenml_secret.test", "name", name+"-updated"),
+					resource.TestCheckResourceAttr("zenml_secret.test", "private", "true"),
+					resource.TestCheckResourceAttr("zenml_secret.test", "values.%", "1"),
+					resource.TestCheckResourceAttr("zenml_secret.test", "values.client_id", "updated-client"),
+					resource.TestCheckNoResourceAttr("zenml_secret.test", "values.client_secret"),
+				),
+			},
+			{
+				ResourceName:      "zenml_secret.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestSecretResourceRejectsRedactedValues(t *testing.T) {
+	var diagnostics diag.Diagnostics
+	resource := SecretResource{}
+	resource.populateSecretModel(
+		context.Background(),
+		&SecretResponse{
+			ID:   "secret-id",
+			Name: "secret-name",
+			Body: &SecretResponseBody{
+				Values: map[string]*string{"password": nil},
+			},
+		},
+		&SecretResourceModel{},
+		&diagnostics,
+	)
+
+	if !diagnostics.HasError() {
+		t.Fatal("expected redacted secret values to produce an error")
+	}
+}
+
+func testAccSecretPreCheck(t *testing.T) {
+	testAccPreCheck(t)
+
+	ctx := context.Background()
+	client := NewClient(
+		os.Getenv("ZENML_SERVER_URL"),
+		os.Getenv("ZENML_API_KEY"),
+		os.Getenv("ZENML_API_TOKEN"),
+	)
+	value := "permission-check"
+	secret, err := client.CreateSecret(ctx, SecretRequest{
+		Name:   "terraform-permission-check-" + acctest.RandString(8),
+		Values: map[string]string{"value": value},
+	})
+	if err != nil {
+		t.Fatalf("acceptance tests require permission to create secrets: %s", err)
+	}
+	defer func() {
+		if err := client.DeleteSecret(ctx, secret.ID); err != nil {
+			t.Errorf("unable to delete secret permission check: %s", err)
+		}
+	}()
+
+	secret, err = client.GetSecret(ctx, secret.ID)
+	if err != nil {
+		t.Fatalf("acceptance tests require permission to read secrets: %s", err)
+	}
+	if secret == nil || secret.Body == nil || secret.Body.Values["value"] == nil {
+		t.Fatal("acceptance tests require READ_SECRET_VALUE permission")
+	}
+}
+
+func testAccSecretConfig(name string, private bool, values map[string]string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "zenml_secret" "test" {
+  name    = %q
+  private = %t
+  values  = %s
+}
+`, testAccProviderConfig(), name, private, terraformStringMap(values))
+}
+
+func terraformStringMap(values map[string]string) string {
+	result := "{\n"
+	for key, value := range values {
+		result += fmt.Sprintf("    %s = %q\n", key, value)
+	}
+	return result + "  }"
+}

--- a/internal/provider/resource_secret_test.go
+++ b/internal/provider/resource_secret_test.go
@@ -110,7 +110,7 @@ func testAccSecretPreCheck(t *testing.T) {
 		t.Fatalf("acceptance tests require permission to read secrets: %s", err)
 	}
 	if secret == nil || secret.Body == nil || secret.Body.Values["value"] == nil {
-		t.Fatal("acceptance tests require READ_SECRET_VALUE permission")
+		t.Fatal("acceptance tests require an account that can read secret values")
 	}
 }
 

--- a/internal/provider/resource_secret_test.go
+++ b/internal/provider/resource_secret_test.go
@@ -18,6 +18,15 @@ TestAccSecret_basic verifies the complete Terraform resource lifecycle:
 3. Update one value and remove another through full-replacement semantics.
 4. Import the secret by UUID and verify that the imported state matches.
 5. Delete the secret during Terraform's automatic test cleanup.
+
+It requires ZENML_SERVER_URL and either ZENML_API_KEY or ZENML_API_TOKEN for
+an active ZenML server account that can manage secrets.
+
+Run with:
+
+export ZENML_SERVER_URL=""
+export ZENML_API_KEY=""
+TF_ACC=1 go test ./internal/provider -run '^TestAccSecret_basic$' -v -count=1 -timeout 20m
 */
 
 func TestAccSecret_basic(t *testing.T) {


### PR DESCRIPTION
Adds a `zenml_secret` resource so ZenML secrets can be managed declaratively alongside stack components.

The resource supports create, read, update, delete, and UUID import operations. It handles redacted values safely, prevents secret values from appearing in debug logs, and documents Terraform state security considerations.

**Testing:**
- Manual Terraform create, update, key removal, import, drift detection, and destroy
- Verified secret values do not appear in debug logs